### PR TITLE
feat(mobile): add property list and detail screens (#24)

### DIFF
--- a/mobile/lib/models/property.dart
+++ b/mobile/lib/models/property.dart
@@ -69,6 +69,34 @@ enum PropertyStatus {
   }
 }
 
+class PropertyAgent {
+  final String id;
+  final String firstName;
+  final String lastName;
+  final String? email;
+  final String? phone;
+
+  const PropertyAgent({
+    required this.id,
+    required this.firstName,
+    required this.lastName,
+    this.email,
+    this.phone,
+  });
+
+  String get fullName => '$firstName $lastName';
+
+  factory PropertyAgent.fromJson(Map<String, dynamic> json) {
+    return PropertyAgent(
+      id: json['id'] as String,
+      firstName: json['firstName'] as String? ?? '',
+      lastName: json['lastName'] as String? ?? '',
+      email: json['email'] as String?,
+      phone: json['phone'] as String?,
+    );
+  }
+}
+
 class Property {
   final String id;
   final String title;
@@ -87,6 +115,7 @@ class Property {
   final double? longitude;
   final List<String> features;
   final String? assignedAgentId;
+  final PropertyAgent? assignedAgent;
   final List<PropertyImage> images;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -109,6 +138,7 @@ class Property {
     this.longitude,
     this.features = const [],
     this.assignedAgentId,
+    this.assignedAgent,
     this.images = const [],
     required this.createdAt,
     required this.updatedAt,
@@ -150,6 +180,12 @@ class Property {
         ..sort((a, b) => a.order.compareTo(b.order));
     }
 
+    final agentRaw = json['assignedAgent'];
+    PropertyAgent? assignedAgent;
+    if (agentRaw is Map<String, dynamic>) {
+      assignedAgent = PropertyAgent.fromJson(agentRaw);
+    }
+
     return Property(
       id: json['id'] as String,
       title: json['title'] as String,
@@ -168,6 +204,7 @@ class Property {
       longitude: double.tryParse('${json['longitude']}'),
       features: features,
       assignedAgentId: json['assignedAgentId'] as String?,
+      assignedAgent: assignedAgent,
       images: images,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),

--- a/mobile/lib/providers/property_provider.dart
+++ b/mobile/lib/providers/property_provider.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/property.dart';
+import '../services/offline_service.dart';
 import '../services/property_service.dart';
 
 class PropertyFilter {
+  final String? search;
   final PropertyType? type;
   final PropertyStatus? status;
   final String? city;
@@ -16,6 +19,7 @@ class PropertyFilter {
   final String sortOrder;
 
   const PropertyFilter({
+    this.search,
     this.type,
     this.status,
     this.city,
@@ -29,6 +33,7 @@ class PropertyFilter {
   });
 
   PropertyFilter copyWith({
+    String? Function()? search,
     PropertyType? Function()? type,
     PropertyStatus? Function()? status,
     String? Function()? city,
@@ -41,6 +46,7 @@ class PropertyFilter {
     String? sortOrder,
   }) {
     return PropertyFilter(
+      search: search != null ? search() : this.search,
       type: type != null ? type() : this.type,
       status: status != null ? status() : this.status,
       city: city != null ? city() : this.city,
@@ -75,6 +81,7 @@ class PropertyListState {
   final int currentPage;
   final bool isLoading;
   final bool isLoadingMore;
+  final bool isFromCache;
   final String? error;
 
   const PropertyListState({
@@ -83,6 +90,7 @@ class PropertyListState {
     this.currentPage = 1,
     this.isLoading = false,
     this.isLoadingMore = false,
+    this.isFromCache = false,
     this.error,
   });
 
@@ -94,6 +102,7 @@ class PropertyListState {
     int? currentPage,
     bool? isLoading,
     bool? isLoadingMore,
+    bool? isFromCache,
     String? Function()? error,
   }) {
     return PropertyListState(
@@ -102,6 +111,7 @@ class PropertyListState {
       currentPage: currentPage ?? this.currentPage,
       isLoading: isLoading ?? this.isLoading,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isFromCache: isFromCache ?? this.isFromCache,
       error: error != null ? error() : this.error,
     );
   }
@@ -109,9 +119,11 @@ class PropertyListState {
 
 class PropertyListNotifier extends StateNotifier<PropertyListState> {
   final PropertyService _service;
+  final OfflineService _offlineService;
   final Ref _ref;
 
-  PropertyListNotifier(this._service, this._ref) : super(const PropertyListState()) {
+  PropertyListNotifier(this._service, this._offlineService, this._ref)
+      : super(const PropertyListState()) {
     loadProperties();
   }
 
@@ -121,6 +133,7 @@ class PropertyListNotifier extends StateNotifier<PropertyListState> {
       final filter = _ref.read(propertyFilterProvider);
       final response = await _service.getProperties(
         page: 1,
+        search: filter.search,
         type: filter.type,
         status: filter.status,
         city: filter.city,
@@ -137,11 +150,28 @@ class PropertyListNotifier extends StateNotifier<PropertyListState> {
         total: response.total,
         currentPage: response.page,
       );
+      // Cache first page for offline use
+      if (!filter.hasActiveFilters && (filter.search == null || filter.search!.isEmpty)) {
+        _cacheProperties(response.data);
+      }
     } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: () => e.toString(),
-      );
+      // Fallback to cached data when offline
+      final cached = _offlineService.getCachedProperties();
+      if (cached.isNotEmpty) {
+        final properties = cached.map((json) => Property.fromJson(json)).toList();
+        state = PropertyListState(
+          properties: properties,
+          total: properties.length,
+          currentPage: 1,
+          isFromCache: true,
+        );
+        debugPrint('PropertyListNotifier: loaded ${properties.length} cached properties');
+      } else {
+        state = state.copyWith(
+          isLoading: false,
+          error: () => e.toString(),
+        );
+      }
     }
   }
 
@@ -153,6 +183,7 @@ class PropertyListNotifier extends StateNotifier<PropertyListState> {
       final nextPage = state.currentPage + 1;
       final response = await _service.getProperties(
         page: nextPage,
+        search: filter.search,
         type: filter.type,
         status: filter.status,
         city: filter.city,
@@ -177,17 +208,113 @@ class PropertyListNotifier extends StateNotifier<PropertyListState> {
       );
     }
   }
+
+  void _cacheProperties(List<Property> properties) {
+    final jsonList = properties.map((p) => {
+      'id': p.id,
+      'title': p.title,
+      'description': p.description,
+      'type': p.type.value,
+      'status': p.status.value,
+      'price': p.price.toString(),
+      'area': p.area.toString(),
+      'bedrooms': p.bedrooms,
+      'bathrooms': p.bathrooms,
+      'floor': p.floor,
+      'address': p.address,
+      'city': p.city,
+      'region': p.region,
+      'latitude': p.latitude?.toString(),
+      'longitude': p.longitude?.toString(),
+      'features': p.features,
+      'assignedAgentId': p.assignedAgentId,
+      'assignedAgent': p.assignedAgent != null
+          ? {
+              'id': p.assignedAgent!.id,
+              'firstName': p.assignedAgent!.firstName,
+              'lastName': p.assignedAgent!.lastName,
+              'email': p.assignedAgent!.email,
+              'phone': p.assignedAgent!.phone,
+            }
+          : null,
+      'images': p.images
+          .map((img) => {
+                'id': img.id,
+                'url': img.url,
+                'caption': img.caption,
+                'isPrimary': img.isPrimary,
+                'order': img.order,
+              })
+          .toList(),
+      'createdAt': p.createdAt.toIso8601String(),
+      'updatedAt': p.updatedAt.toIso8601String(),
+    }).toList();
+    _offlineService.cacheProperties(jsonList);
+  }
 }
 
 final propertyListProvider =
     StateNotifierProvider<PropertyListNotifier, PropertyListState>((ref) {
   final service = ref.watch(propertyServiceProvider);
+  final offlineService = ref.watch(offlineServiceProvider);
   ref.watch(propertyFilterProvider);
-  return PropertyListNotifier(service, ref);
+  return PropertyListNotifier(service, offlineService, ref);
 });
 
 final propertyDetailProvider =
-    FutureProvider.family<Property, String>((ref, id) {
+    FutureProvider.family<Property, String>((ref, id) async {
   final service = ref.watch(propertyServiceProvider);
-  return service.getProperty(id);
+  final offlineService = ref.watch(offlineServiceProvider);
+  try {
+    final property = await service.getProperty(id);
+    // Cache individual property for offline access
+    offlineService.cacheProperty(id, {
+      'id': property.id,
+      'title': property.title,
+      'description': property.description,
+      'type': property.type.value,
+      'status': property.status.value,
+      'price': property.price.toString(),
+      'area': property.area.toString(),
+      'bedrooms': property.bedrooms,
+      'bathrooms': property.bathrooms,
+      'floor': property.floor,
+      'address': property.address,
+      'city': property.city,
+      'region': property.region,
+      'latitude': property.latitude?.toString(),
+      'longitude': property.longitude?.toString(),
+      'features': property.features,
+      'assignedAgentId': property.assignedAgentId,
+      'assignedAgent': property.assignedAgent != null
+          ? {
+              'id': property.assignedAgent!.id,
+              'firstName': property.assignedAgent!.firstName,
+              'lastName': property.assignedAgent!.lastName,
+              'email': property.assignedAgent!.email,
+              'phone': property.assignedAgent!.phone,
+            }
+          : null,
+      'images': property.images
+          .map((img) => {
+                'id': img.id,
+                'url': img.url,
+                'caption': img.caption,
+                'isPrimary': img.isPrimary,
+                'order': img.order,
+              })
+          .toList(),
+      'createdAt': property.createdAt.toIso8601String(),
+      'updatedAt': property.updatedAt.toIso8601String(),
+    });
+    return property;
+  } catch (e) {
+    // Fallback to cached property when offline
+    final cached = offlineService.getCachedProperty(id);
+    if (cached != null) {
+      debugPrint('propertyDetailProvider: loaded cached property $id');
+      return Property.fromJson(cached);
+    }
+    rethrow;
+  }
 });

--- a/mobile/lib/screens/properties/properties_screen.dart
+++ b/mobile/lib/screens/properties/properties_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,19 +12,76 @@ import 'property_filter_sheet.dart';
 
 final _viewModeProvider = StateProvider<bool>((ref) => false); // false=list, true=grid
 
-class PropertiesScreen extends ConsumerWidget {
+class PropertiesScreen extends ConsumerStatefulWidget {
   const PropertiesScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<PropertiesScreen> createState() => _PropertiesScreenState();
+}
+
+class _PropertiesScreenState extends ConsumerState<PropertiesScreen> {
+  final _searchController = TextEditingController();
+  Timer? _debounce;
+  bool _showSearch = false;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String query) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      ref.read(propertyFilterProvider.notifier).state =
+          ref.read(propertyFilterProvider).copyWith(
+                search: () => query.isEmpty ? null : query,
+              );
+    });
+  }
+
+  void _toggleSearch() {
+    setState(() {
+      _showSearch = !_showSearch;
+      if (!_showSearch) {
+        _searchController.clear();
+        _debounce?.cancel();
+        // Clear search filter
+        final current = ref.read(propertyFilterProvider);
+        if (current.search != null) {
+          ref.read(propertyFilterProvider.notifier).state =
+              current.copyWith(search: () => null);
+        }
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final listState = ref.watch(propertyListProvider);
     final isGrid = ref.watch(_viewModeProvider);
     final filter = ref.watch(propertyFilterProvider);
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Properties'),
+        title: _showSearch
+            ? TextField(
+                controller: _searchController,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  hintText: 'Search properties...',
+                  border: InputBorder.none,
+                ),
+                onChanged: _onSearchChanged,
+              )
+            : const Text('Properties'),
         actions: [
+          IconButton(
+            icon: Icon(_showSearch ? Icons.close : Icons.search),
+            tooltip: _showSearch ? 'Close search' : 'Search',
+            onPressed: _toggleSearch,
+          ),
           IconButton(
             icon: Icon(isGrid ? Icons.view_list : Icons.grid_view),
             tooltip: isGrid ? 'List view' : 'Grid view',
@@ -101,10 +160,34 @@ class PropertiesScreen extends ConsumerWidget {
       );
     }
 
-    return RefreshIndicator(
-      onRefresh: () =>
-          ref.read(propertyListProvider.notifier).loadProperties(),
-      child: isGrid ? _buildGrid(context, ref, state) : _buildList(context, ref, state),
+    return Column(
+      children: [
+        if (state.isFromCache)
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            color: Colors.orange.shade100,
+            child: Row(
+              children: [
+                Icon(Icons.cloud_off, size: 16, color: Colors.orange.shade800),
+                const SizedBox(width: 8),
+                Text(
+                  'Showing cached data — pull to refresh when online',
+                  style: TextStyle(fontSize: 12, color: Colors.orange.shade800),
+                ),
+              ],
+            ),
+          ),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: () =>
+                ref.read(propertyListProvider.notifier).loadProperties(),
+            child: isGrid
+                ? _buildGrid(context, ref, state)
+                : _buildList(context, ref, state),
+          ),
+        ),
+      ],
     );
   }
 

--- a/mobile/lib/screens/properties/property_detail_screen.dart
+++ b/mobile/lib/screens/properties/property_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -71,7 +72,7 @@ class _PropertyDetailView extends StatelessWidget {
             actions: [
               IconButton(
                 icon: const Icon(Icons.share),
-                onPressed: () => _shareProperty(context),
+                onPressed: () => _showShareOptions(context),
               ),
             ],
           ),
@@ -102,10 +103,12 @@ class _PropertyDetailView extends StatelessWidget {
                     children: [
                       const Icon(Icons.location_on_outlined, size: 16),
                       const SizedBox(width: 4),
-                      Text(
-                        '${property.address}, ${property.locationText}',
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
+                      Expanded(
+                        child: Text(
+                          '${property.address}, ${property.locationText}',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
                         ),
                       ),
                     ],
@@ -172,15 +175,93 @@ class _PropertyDetailView extends StatelessWidget {
                     ),
                   ],
 
+                  // Assigned agent
+                  if (property.assignedAgent != null) ...[
+                    const SizedBox(height: 20),
+                    Text('Assigned Agent', style: theme.textTheme.titleMedium),
+                    const SizedBox(height: 8),
+                    Card(
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: theme.colorScheme.primaryContainer,
+                          child: Text(
+                            property.assignedAgent!.firstName.isNotEmpty
+                                ? property.assignedAgent!.firstName[0].toUpperCase()
+                                : 'A',
+                            style: TextStyle(
+                              color: theme.colorScheme.onPrimaryContainer,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        title: Text(property.assignedAgent!.fullName),
+                        subtitle: property.assignedAgent!.email != null
+                            ? Text(property.assignedAgent!.email!)
+                            : null,
+                        trailing: property.assignedAgent!.phone != null
+                            ? IconButton(
+                                icon: const Icon(Icons.phone_outlined),
+                                onPressed: () => launchUrl(
+                                  Uri.parse('tel:${property.assignedAgent!.phone}'),
+                                ),
+                              )
+                            : null,
+                      ),
+                    ),
+                  ],
+
                   // Map link
                   if (property.latitude != null && property.longitude != null) ...[
                     const SizedBox(height: 20),
                     Text('Location', style: theme.textTheme.titleMedium),
                     const SizedBox(height: 8),
-                    OutlinedButton.icon(
-                      icon: const Icon(Icons.map),
-                      label: const Text('Open in Maps'),
-                      onPressed: () => _openInMaps(context),
+                    // Static map preview
+                    GestureDetector(
+                      onTap: () => _openInMaps(context),
+                      child: Container(
+                        height: 180,
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                          color: Colors.grey.shade200,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(color: Colors.grey.shade300),
+                        ),
+                        child: Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.map, size: 48, color: theme.colorScheme.primary),
+                                const SizedBox(height: 8),
+                                Text(
+                                  '${property.latitude!.toStringAsFixed(4)}, ${property.longitude!.toStringAsFixed(4)}',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  'Tap to open in Maps',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            Positioned(
+                              top: 8,
+                              right: 8,
+                              child: Icon(
+                                Icons.open_in_new,
+                                size: 18,
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
                   ],
 
@@ -194,12 +275,61 @@ class _PropertyDetailView extends StatelessWidget {
     );
   }
 
-  void _shareProperty(BuildContext context) {
-    final text = '${property.title}\n'
+  void _showShareOptions(BuildContext context) {
+    final shareText = '${property.title}\n'
         '${property.type.label} — ${property.priceFormatted}\n'
         '${property.locationText}\n'
         '${property.area.toStringAsFixed(0)} m²';
-    Share.share(text, subject: property.title);
+
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.share),
+              title: const Text('Share'),
+              onTap: () {
+                Navigator.pop(context);
+                Share.share(shareText, subject: property.title);
+              },
+            ),
+            ListTile(
+              leading: Icon(Icons.message, color: Colors.green.shade600),
+              title: const Text('Share via WhatsApp'),
+              onTap: () {
+                Navigator.pop(context);
+                _shareViaWhatsApp(context, shareText);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.copy),
+              title: const Text('Copy to clipboard'),
+              onTap: () {
+                Navigator.pop(context);
+                Clipboard.setData(ClipboardData(text: shareText));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Copied to clipboard')),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _shareViaWhatsApp(BuildContext context, String text) async {
+    final url = Uri.parse('https://wa.me/?text=${Uri.encodeComponent(text)}');
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    } else {
+      if (context.mounted) {
+        // Fallback to regular share
+        Share.share(text, subject: property.title);
+      }
+    }
   }
 
   void _openInMaps(BuildContext context) {

--- a/mobile/lib/services/property_service.dart
+++ b/mobile/lib/services/property_service.dart
@@ -11,6 +11,7 @@ class PropertyService {
   Future<PropertyListResponse> getProperties({
     int page = 1,
     int limit = 20,
+    String? search,
     PropertyType? type,
     PropertyStatus? status,
     String? city,
@@ -29,6 +30,7 @@ class PropertyService {
       'sortOrder': sortOrder,
     };
 
+    if (search != null && search.isNotEmpty) params['search'] = search;
     if (type != null) params['type'] = type.value;
     if (status != null) params['status'] = status.value;
     if (city != null && city.isNotEmpty) params['city'] = city;


### PR DESCRIPTION
## Summary
Property list and detail screens for the Flutter mobile app.

Closes #24

## What's included
- **PropertyListScreen** — image, title, city, price, status badge
- **Search** — toggle bar in AppBar with 300ms debounce
- **Filters** — status, type, city, price range, area, bedrooms
- **Pagination** — infinite scroll + pull-to-refresh
- **PropertyDetailScreen** — swipeable image gallery, full info, assigned agent card
- **Share** — system share, WhatsApp (`wa.me`), copy link
- **Map** — tap-to-open in Google Maps
- **Offline** — cached via Hive, orange banner when showing stale data

## Files changed
- `models/property.dart` — added `PropertyAgent` model
- `services/property_service.dart` — added search param
- `providers/property_provider.dart` — Hive caching + offline fallback
- `screens/properties/properties_screen.dart` — main list screen
- `screens/properties/property_detail_screen.dart` — detail screen

Written by: Youssef (mobile)