### PR TITLE
feat(auth): connect admin-ui & agent-ui to AuthMe OIDC (#3)

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
+        "authme-sdk": "^1.0.0",
         "axios": "^1.13.6",
         "clsx": "^2.1.1",
         "lucide-react": "^1.6.0",
@@ -2258,6 +2259,24 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/authme-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/authme-sdk/-/authme-sdk-1.0.0.tgz",
+      "integrity": "sha512-J1y3/LEuyNYReNSFm6xrlx3tEayuEApj/oxWRNcqyXqmBo1TmKHqIFtHBI7isfj3/NVw5QjbUIc5nfc0VlvXYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jose": ">=5.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/axios": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
@@ -3311,7 +3330,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -4501,7 +4519,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.95.2",
+    "authme-sdk": "^1.0.0",
     "axios": "^1.13.6",
     "clsx": "^2.1.1",
     "lucide-react": "^1.6.0",

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -8,6 +8,7 @@ import { Layout } from './components/layout/Layout'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
 
 import LoginPage from './pages/LoginPage'
+import CallbackPage from './pages/CallbackPage'
 import DashboardPage from './pages/DashboardPage'
 import PropertiesListPage from './pages/properties/PropertiesListPage'
 import PropertyDetailPage from './pages/properties/PropertyDetailPage'
@@ -48,6 +49,7 @@ export default function App() {
               <Routes>
                 {/* Public */}
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/callback" element={<CallbackPage />} />
 
                 {/* Protected — wrapped in Layout */}
                 <Route

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { authme } from '../lib/authme'
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
 
@@ -9,10 +10,10 @@ export const apiClient = axios.create({
   },
 })
 
-// Request interceptor — inject Bearer token
+// Request interceptor — inject Bearer token from AuthMe SDK
 apiClient.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('access_token')
+    const token = authme.getAccessToken()
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
@@ -26,8 +27,6 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('access_token')
-      localStorage.removeItem('user')
       window.location.href = '/login'
     }
     return Promise.reject(error)

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -1,80 +1,57 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
-import apiClient from '../api/client'
-import type { User, LoginCredentials, LoginResponse } from '../types'
+import React, { createContext, useContext } from 'react'
+import { AuthProvider as AuthmeProvider, useAuth as useAuthme, useUser } from 'authme-sdk/react'
+import { authme } from '../lib/authme'
+import type { User } from '../types'
 
 interface AuthContextValue {
   user: User | null
   token: string | null
   isAuthenticated: boolean
   isLoading: boolean
-  login: (credentials: LoginCredentials) => Promise<void>
+  login: () => Promise<void>
   logout: () => void
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
-function loadStoredAuth(): { user: User | null; token: string | null } {
-  try {
-    const token = localStorage.getItem('access_token')
-    const userRaw = localStorage.getItem('user')
-    const user: User | null = userRaw ? JSON.parse(userRaw) : null
-    return { token, user }
-  } catch {
-    return { token: null, user: null }
-  }
-}
+function AuthContextBridge({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isLoading, login, logout, getToken } = useAuthme()
+  const authmeUser = useUser()
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null)
-  const [token, setToken] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const navigate = useNavigate()
+  // Map AuthMe user profile to our internal User type
+  const user: User | null = authmeUser
+    ? {
+        id: authmeUser.sub ?? '',
+        email: authmeUser.email ?? '',
+        name: authmeUser.name ?? authmeUser.preferred_username ?? '',
+        role: (authmeUser as Record<string, unknown>)['role'] as string ?? 'admin',
+      }
+    : null
 
-  // Hydrate from localStorage on mount
-  useEffect(() => {
-    const stored = loadStoredAuth()
-    if (stored.token && stored.user) {
-      setToken(stored.token)
-      setUser(stored.user)
-    }
-    setIsLoading(false)
-  }, [])
-
-  const login = useCallback(async (credentials: LoginCredentials) => {
-    const response = await apiClient.post<LoginResponse>('/auth/login', credentials)
-    const { access_token, user: loggedInUser } = response.data
-
-    localStorage.setItem('access_token', access_token)
-    localStorage.setItem('user', JSON.stringify(loggedInUser))
-
-    setToken(access_token)
-    setUser(loggedInUser)
-    navigate('/')
-  }, [navigate])
-
-  const logout = useCallback(() => {
-    localStorage.removeItem('access_token')
-    localStorage.removeItem('user')
-    setToken(null)
-    setUser(null)
-    navigate('/login')
-  }, [navigate])
+  const token = getToken?.() ?? null
 
   return (
     <AuthContext.Provider
       value={{
         user,
         token,
-        isAuthenticated: !!token && !!user,
+        isAuthenticated,
         isLoading,
-        login,
+        login: () => login(),
         logout,
       }}
     >
       {children}
     </AuthContext.Provider>
+  )
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthmeProvider client={authme}>
+      <AuthContextBridge>{children}</AuthContextBridge>
+    </AuthmeProvider>
   )
 }
 

--- a/admin-ui/src/lib/authme.ts
+++ b/admin-ui/src/lib/authme.ts
@@ -1,0 +1,10 @@
+import { AuthmeClient } from 'authme-sdk'
+
+export const authme = new AuthmeClient({
+  url: import.meta.env.VITE_AUTHME_URL ?? 'https://dev-auth.realstate-crm.homes',
+  realm: import.meta.env.VITE_AUTHME_REALM ?? 'real-estate-dev',
+  clientId: import.meta.env.VITE_AUTHME_CLIENT_ID ?? 'admin-portal',
+  redirectUri:
+    import.meta.env.VITE_AUTHME_REDIRECT_URI ??
+    'https://dev-admin.realstate-crm.homes/callback',
+})

--- a/admin-ui/src/pages/CallbackPage.tsx
+++ b/admin-ui/src/pages/CallbackPage.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { authme } from '../lib/authme'
+
+/**
+ * OAuth2 / OIDC callback handler.
+ * AuthMe redirects here after the user authenticates.
+ * The SDK exchanges the authorization code for tokens and restores the session.
+ */
+export default function CallbackPage() {
+  const navigate = useNavigate()
+  const handled = useRef(false)
+
+  useEffect(() => {
+    if (handled.current) return
+    handled.current = true
+
+    async function handleCallback() {
+      try {
+        const success = await authme.handleCallback()
+        if (success) {
+          navigate('/', { replace: true })
+        } else {
+          navigate('/login', { replace: true })
+        }
+      } catch {
+        navigate('/login', { replace: true })
+      }
+    }
+
+    handleCallback()
+  }, [navigate])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+      <div className="text-center space-y-3">
+        <div className="inline-block w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin" />
+        <p className="text-sm text-gray-500 dark:text-gray-400">Signing you in…</p>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/LoginPage.tsx
+++ b/admin-ui/src/pages/LoginPage.tsx
@@ -1,50 +1,13 @@
-import { useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { Building, Mail, Lock } from 'lucide-react'
+import { Building } from 'lucide-react'
 import { useAuth } from '../context/AuthContext'
-import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
-import toast from 'react-hot-toast'
 
 export default function LoginPage() {
   const { login, isAuthenticated, isLoading } = useAuth()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [submitting, setSubmitting] = useState(false)
-  const [errors, setErrors] = useState<{ email?: string; password?: string }>({})
 
   if (!isLoading && isAuthenticated) {
     return <Navigate to="/" replace />
-  }
-
-  function validate() {
-    const errs: typeof errors = {}
-    if (!email) errs.email = 'Email is required'
-    else if (!/\S+@\S+\.\S+/.test(email)) errs.email = 'Enter a valid email'
-    if (!password) errs.password = 'Password is required'
-    return errs
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const errs = validate()
-    if (Object.keys(errs).length) {
-      setErrors(errs)
-      return
-    }
-    setErrors({})
-    setSubmitting(true)
-    try {
-      await login({ email, password })
-      toast.success('Welcome back!')
-    } catch (err: unknown) {
-      const msg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
-        'Invalid credentials. Please try again.'
-      toast.error(msg)
-    } finally {
-      setSubmitting(false)
-    }
   }
 
   return (
@@ -63,37 +26,15 @@ export default function LoginPage() {
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
-            <Input
-              label="Email address"
-              type="email"
-              placeholder="you@company.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              error={errors.email}
-              required
-              leftAddon={<Mail size={15} />}
-            />
-            <Input
-              label="Password"
-              type="password"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              error={errors.password}
-              required
-              leftAddon={<Lock size={15} />}
-            />
-
-            <Button
-              type="submit"
-              loading={submitting}
-              className="mt-2 w-full"
-              size="lg"
-            >
-              Sign in
-            </Button>
-          </form>
+          <Button
+            type="button"
+            className="mt-2 w-full"
+            size="lg"
+            onClick={() => login()}
+            loading={isLoading}
+          >
+            Sign in with AuthMe
+          </Button>
 
           <p className="mt-6 text-center text-xs text-gray-400 dark:text-gray-500">
             Secure admin access &mdash; Real Estate CRM &copy; {new Date().getFullYear()}

--- a/agent-ui/.env.example
+++ b/agent-ui/.env.example
@@ -3,5 +3,5 @@ VITE_API_URL=http://localhost:3000
 # AuthMe OIDC configuration
 VITE_AUTHME_URL=https://dev-auth.realstate-crm.homes
 VITE_AUTHME_REALM=real-estate-dev
-VITE_AUTHME_CLIENT_ID=admin-portal
-VITE_AUTHME_REDIRECT_URI=https://dev-admin.realstate-crm.homes/callback
+VITE_AUTHME_CLIENT_ID=agent-portal
+VITE_AUTHME_REDIRECT_URI=https://dev-agent.realstate-crm.homes/callback

--- a/agent-ui/package-lock.json
+++ b/agent-ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
+        "authme-sdk": "^1.0.0",
         "axios": "^1.13.6",
         "clsx": "^2.1.1",
         "lucide-react": "^1.6.0",
@@ -2257,6 +2258,24 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/authme-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/authme-sdk/-/authme-sdk-1.0.0.tgz",
+      "integrity": "sha512-J1y3/LEuyNYReNSFm6xrlx3tEayuEApj/oxWRNcqyXqmBo1TmKHqIFtHBI7isfj3/NVw5QjbUIc5nfc0VlvXYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jose": ">=5.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/axios": {
       "version": "1.13.6",

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.95.2",
+    "authme-sdk": "^1.0.0",
     "axios": "^1.13.6",
     "clsx": "^2.1.1",
     "lucide-react": "^1.6.0",

--- a/agent-ui/src/App.tsx
+++ b/agent-ui/src/App.tsx
@@ -8,6 +8,7 @@ import { Layout } from './components/layout/Layout'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
 
 import LoginPage from './pages/LoginPage'
+import CallbackPage from './pages/CallbackPage'
 import DashboardPage from './pages/DashboardPage'
 import PropertiesPage from './pages/PropertiesPage'
 import LeadsPage from './pages/LeadsPage'
@@ -34,6 +35,7 @@ export default function App() {
               <Routes>
                 {/* Public */}
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/callback" element={<CallbackPage />} />
 
                 {/* Protected — wrapped in Layout */}
                 <Route

--- a/agent-ui/src/api/client.ts
+++ b/agent-ui/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { authme } from '../lib/authme'
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
 
@@ -9,10 +10,10 @@ export const apiClient = axios.create({
   },
 })
 
-// Request interceptor — inject Bearer token
+// Request interceptor — inject Bearer token from AuthMe SDK
 apiClient.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('access_token')
+    const token = authme.getAccessToken()
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
@@ -26,8 +27,6 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('access_token')
-      localStorage.removeItem('user')
       window.location.href = '/login'
     }
     return Promise.reject(error)

--- a/agent-ui/src/context/AuthContext.tsx
+++ b/agent-ui/src/context/AuthContext.tsx
@@ -1,72 +1,56 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
-import apiClient from '../api/client'
-import { loadStoredAuth } from '../utils/auth'
-import type { User, LoginCredentials, LoginResponse } from '../types'
+import React, { createContext, useContext } from 'react'
+import { AuthProvider as AuthmeProvider, useAuth as useAuthme, useUser } from 'authme-sdk/react'
+import { authme } from '../lib/authme'
+import type { User } from '../types'
 
 interface AuthContextValue {
   user: User | null
   token: string | null
   isAuthenticated: boolean
   isLoading: boolean
-  login: (credentials: LoginCredentials) => Promise<void>
+  login: () => Promise<void>
   logout: () => void
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null)
-  const [token, setToken] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const navigate = useNavigate()
+function AuthContextBridge({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isLoading, login, logout, getToken } = useAuthme()
+  const authmeUser = useUser()
 
-  // Hydrate from localStorage on mount
-  useEffect(() => {
-    const stored = loadStoredAuth()
-    if (stored.token && stored.user) {
-      setToken(stored.token)
-      setUser(stored.user)
-    }
-    setIsLoading(false)
-  }, [])
+  // Map AuthMe user profile to our internal User type
+  const user: User | null = authmeUser
+    ? {
+        id: authmeUser.sub ?? '',
+        email: authmeUser.email ?? '',
+        name: authmeUser.name ?? authmeUser.preferred_username ?? '',
+        role: (authmeUser as Record<string, unknown>)['role'] as string ?? 'agent',
+      }
+    : null
 
-  const login = useCallback(
-    async (credentials: LoginCredentials) => {
-      const response = await apiClient.post<LoginResponse>('/auth/login', credentials)
-      const { access_token, user: loggedInUser } = response.data
-
-      localStorage.setItem('access_token', access_token)
-      localStorage.setItem('user', JSON.stringify(loggedInUser))
-
-      setToken(access_token)
-      setUser(loggedInUser)
-      navigate('/')
-    },
-    [navigate],
-  )
-
-  const logout = useCallback(() => {
-    localStorage.removeItem('access_token')
-    localStorage.removeItem('user')
-    setToken(null)
-    setUser(null)
-    navigate('/login')
-  }, [navigate])
+  const token = getToken?.() ?? null
 
   return (
     <AuthContext.Provider
       value={{
         user,
         token,
-        isAuthenticated: !!token && !!user,
+        isAuthenticated,
         isLoading,
-        login,
+        login: () => login(),
         logout,
       }}
     >
       {children}
     </AuthContext.Provider>
+  )
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthmeProvider client={authme}>
+      <AuthContextBridge>{children}</AuthContextBridge>
+    </AuthmeProvider>
   )
 }
 

--- a/agent-ui/src/lib/authme.ts
+++ b/agent-ui/src/lib/authme.ts
@@ -1,0 +1,10 @@
+import { AuthmeClient } from 'authme-sdk'
+
+export const authme = new AuthmeClient({
+  url: import.meta.env.VITE_AUTHME_URL ?? 'https://dev-auth.realstate-crm.homes',
+  realm: import.meta.env.VITE_AUTHME_REALM ?? 'real-estate-dev',
+  clientId: import.meta.env.VITE_AUTHME_CLIENT_ID ?? 'agent-portal',
+  redirectUri:
+    import.meta.env.VITE_AUTHME_REDIRECT_URI ??
+    'https://dev-agent.realstate-crm.homes/callback',
+})

--- a/agent-ui/src/pages/CallbackPage.tsx
+++ b/agent-ui/src/pages/CallbackPage.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { authme } from '../lib/authme'
+
+/**
+ * OAuth2 / OIDC callback handler.
+ * AuthMe redirects here after the user authenticates.
+ * The SDK exchanges the authorization code for tokens and restores the session.
+ */
+export default function CallbackPage() {
+  const navigate = useNavigate()
+  const handled = useRef(false)
+
+  useEffect(() => {
+    if (handled.current) return
+    handled.current = true
+
+    async function handleCallback() {
+      try {
+        const success = await authme.handleCallback()
+        if (success) {
+          navigate('/', { replace: true })
+        } else {
+          navigate('/login', { replace: true })
+        }
+      } catch {
+        navigate('/login', { replace: true })
+      }
+    }
+
+    handleCallback()
+  }, [navigate])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+      <div className="text-center space-y-3">
+        <div className="inline-block w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin" />
+        <p className="text-sm text-gray-500 dark:text-gray-400">Signing you in…</p>
+      </div>
+    </div>
+  )
+}

--- a/agent-ui/src/pages/LoginPage.tsx
+++ b/agent-ui/src/pages/LoginPage.tsx
@@ -1,50 +1,13 @@
-import { useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { Building, Mail, Lock } from 'lucide-react'
+import { Building } from 'lucide-react'
 import { useAuth } from '../context/AuthContext'
-import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
-import toast from 'react-hot-toast'
 
 export default function LoginPage() {
   const { login, isAuthenticated, isLoading } = useAuth()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [submitting, setSubmitting] = useState(false)
-  const [errors, setErrors] = useState<{ email?: string; password?: string }>({})
 
   if (!isLoading && isAuthenticated) {
     return <Navigate to="/" replace />
-  }
-
-  function validate() {
-    const errs: typeof errors = {}
-    if (!email) errs.email = 'Email is required'
-    else if (!/\S+@\S+\.\S+/.test(email)) errs.email = 'Enter a valid email'
-    if (!password) errs.password = 'Password is required'
-    return errs
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const errs = validate()
-    if (Object.keys(errs).length) {
-      setErrors(errs)
-      return
-    }
-    setErrors({})
-    setSubmitting(true)
-    try {
-      await login({ email, password })
-      toast.success('Welcome back!')
-    } catch (err: unknown) {
-      const msg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
-        'Invalid credentials. Please try again.'
-      toast.error(msg)
-    } finally {
-      setSubmitting(false)
-    }
   }
 
   return (
@@ -63,37 +26,15 @@ export default function LoginPage() {
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
-            <Input
-              label="Email address"
-              type="email"
-              placeholder="you@company.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              error={errors.email}
-              required
-              leftAddon={<Mail size={15} />}
-            />
-            <Input
-              label="Password"
-              type="password"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              error={errors.password}
-              required
-              leftAddon={<Lock size={15} />}
-            />
-
-            <Button
-              type="submit"
-              loading={submitting}
-              className="mt-2 w-full"
-              size="lg"
-            >
-              Sign in
-            </Button>
-          </form>
+          <Button
+            type="button"
+            className="mt-2 w-full"
+            size="lg"
+            onClick={() => login()}
+            loading={isLoading}
+          >
+            Sign in with AuthMe
+          </Button>
 
           <p className="mt-6 text-center text-xs text-gray-400 dark:text-gray-500">
             Secure agent access &mdash; Real Estate CRM &copy; {new Date().getFullYear()}


### PR DESCRIPTION
## Summary

Connects both frontend apps to **AuthMe** using the official `authme-sdk` and OAuth 2.0 Authorization Code + PKCE flow.

## Changes

### Both UIs (admin-ui & agent-ui)
- **`npm install authme-sdk`** — official AuthMe TypeScript SDK
- **`src/lib/authme.ts`** — `AuthmeClient` configured via env vars (with hardcoded fallbacks for dev)
- **`src/context/AuthContext.tsx`** — replaced direct JWT logic with `authme-sdk/react` `AuthProvider` + bridge; keeps identical `useAuth()` interface so existing components need no changes
- **`src/pages/CallbackPage.tsx`** — handles `/callback` route: calls `authme.handleCallback()` then redirects to `/`
- **`src/pages/LoginPage.tsx`** — replaced email/password form with single "Sign in with AuthMe" button that triggers OIDC redirect
- **`src/api/client.ts`** — updated interceptor to use `authme.getAccessToken()` instead of `localStorage`
- **`.env.example`** — added all `VITE_AUTHME_*` vars

## Config
| App | Client ID | Redirect URI |
|-----|-----------|--------------|
| admin-ui | `admin-portal` | `https://dev-admin.realstate-crm.homes/callback` |
| agent-ui | `agent-portal` | `https://dev-agent.realstate-crm.homes/callback` |

AuthMe server: `https://dev-auth.realstate-crm.homes` · Realm: `real-estate-dev`

## Testing
1. Visit `/login` → click **Sign in with AuthMe** → redirected to AuthMe login page
2. Authenticate → redirected to `/callback` → token exchanged → redirected to `/`
3. All API calls now carry `Authorization: Bearer <authme_token>`

Closes #3