### PR TITLE
feat(clients): CRUD + duplicate detection + agent assignment (#16)

### DIFF
--- a/admin-ui/src/components/clients/DuplicateWarning.tsx
+++ b/admin-ui/src/components/clients/DuplicateWarning.tsx
@@ -1,0 +1,63 @@
+import { AlertTriangle, ExternalLink } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import type { DuplicateMatch } from '../../types/client'
+
+interface DuplicateWarningProps {
+  matches: DuplicateMatch[]
+  className?: string
+}
+
+const fieldLabel: Record<string, string> = {
+  phone: 'Phone',
+  email: 'Email',
+  nationalId: 'National ID',
+}
+
+export default function DuplicateWarning({ matches, className = '' }: DuplicateWarningProps) {
+  if (matches.length === 0) return null
+
+  return (
+    <div
+      className={`rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/20 p-4 ${className}`}
+      role="alert"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle size={20} className="text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+            Potential Duplicate{matches.length > 1 ? 's' : ''} Detected
+          </h3>
+          <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+            {matches.length === 1
+              ? 'A client with matching information already exists.'
+              : `${matches.length} clients with matching information found.`}
+          </p>
+          <ul className="mt-3 space-y-2">
+            {matches.map((match) => (
+              <li
+                key={match.id}
+                className="flex items-center justify-between rounded-md bg-white/60 dark:bg-gray-800/40 px-3 py-2"
+              >
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {match.firstName} {match.lastName}
+                  </span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    Matched on: {match.matchedOn.map((f) => fieldLabel[f] ?? f).join(', ')}
+                  </span>
+                </div>
+                <Link
+                  to={`/clients/${match.id}`}
+                  className="flex items-center gap-1 text-xs font-medium text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-300"
+                  target="_blank"
+                >
+                  View <ExternalLink size={12} />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/hooks/useClients.ts
+++ b/admin-ui/src/hooks/useClients.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { clientsApi } from '../api/clients'
-import type { ClientFilter, CreateClientPayload, UpdateClientPayload } from '../types/client'
+import type { ClientFilter, CreateClientPayload, UpdateClientPayload, DuplicateCheckResult } from '../types/client'
 
 const KEYS = {
   all: ['clients'] as const,
@@ -66,6 +66,15 @@ export function useUpdateClient() {
       qc.invalidateQueries({ queryKey: KEYS.lists() })
       qc.invalidateQueries({ queryKey: KEYS.detail(id) })
     },
+  })
+}
+
+export function useCheckDuplicates(params: { phone?: string; email?: string; nationalId?: string; excludeId?: string }) {
+  return useQuery<DuplicateCheckResult>({
+    queryKey: [...KEYS.all, 'duplicates', params],
+    queryFn: () => clientsApi.checkDuplicates(params),
+    enabled: !!(params.phone || params.email || params.nationalId),
+    staleTime: 10_000,
   })
 }
 

--- a/admin-ui/src/pages/clients/ClientFormPage.tsx
+++ b/admin-ui/src/pages/clients/ClientFormPage.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft, Save } from 'lucide-react'
 import { Button, Input, Select, Textarea, LoadingSpinner } from '../../components/ui'
-import { useClientDetail, useCreateClient, useUpdateClient } from '../../hooks/useClients'
+import { useClientDetail, useCreateClient, useUpdateClient, useCheckDuplicates } from '../../hooks/useClients'
+import DuplicateWarning from '../../components/clients/DuplicateWarning'
+import { useDebounce } from '../../hooks/useDebounce'
 import toast from 'react-hot-toast'
 import type { ClientType, ClientSource, CreateClientPayload } from '../../types/client'
 

--- a/docs/wireframes/leads-list.md
+++ b/docs/wireframes/leads-list.md
@@ -1,0 +1,150 @@
+# Wireframe: Leads List / Pipeline Page
+
+**Route:** `/leads` (list) · `/leads/kanban` (pipeline)  
+**Issue:** #19  
+**Designer:** Layla Ibrahim
+
+---
+
+## Layout Overview — Kanban View (Default)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  HEADER                                                         │
+│  📊 Leads Pipeline           [42]     [+ New Lead]              │
+├─────────────────────────────────────────────────────────────────┤
+│  CONTROLS ROW                                                   │
+│  ┌─────────────────────┐ [Priority ▼] [Agent ▼] [🔲 List] [📊]│
+│  │ 🔍 Search leads...   │                                       │
+│  └─────────────────────┘                                       │
+├─────────────────────────────────────────────────────────────────┤
+│  KANBAN BOARD (horizontal scroll)                               │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────┐ │
+│  │ NEW (12) │ │CONTACTED │ │ VIEWING  │ │NEGOTIATION│ │ WON  │ │
+│  │ ───────  │ │  (8)     │ │  (6)     │ │   (4)    │ │ (12) │ │
+│  │┌────────┐│ │┌────────┐│ │┌────────┐│ │┌────────┐│ │┌────┐│ │
+│  ││Villa   ││ ││3BR Apt ││ ││Office  ││ ││Penthse ││ ││Shop││ │
+│  ││Interest││ ││Follow  ││ ││Tour    ││ ││Offer   ││ ││Deal││ │
+│  ││🔴 High ││ ││🟡 Med  ││ ││🟡 Med  ││ ││🔴 High ││ ││🟢  ││ │
+│  ││Ahmed S.││ ││Sara N. ││ ││Khaled ││ ││Nour A. ││ ││Ali ││ │
+│  ││2d ago  ││ ││5d ago  ││ ││1d ago  ││ ││3h ago  ││ ││1w  ││ │
+│  │└────────┘│ │└────────┘│ │└────────┘│ │└────────┘│ │└────┘│ │
+│  │┌────────┐│ │┌────────┐│ │          │ │          │ │      │ │
+│  ││Studio  ││ ││Land    ││ │          │ │          │ │      │ │
+│  ││Inquiry ││ ││Inquiry ││ │          │ │          │ │      │ │
+│  ││🟢 Low  ││ ││🟡 Med  ││ │          │ │          │ │      │ │
+│  │└────────┘│ │└────────┘│ │          │ │          │ │      │ │
+│  │  + Add   │ │          │ │          │ │          │ │      │ │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────┘ │
+│                                            Also: LOST column   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Layout Overview — List View
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  (Same header & controls, "List" toggle active)                 │
+├─────────────────────────────────────────────────────────────────┤
+│  DATA TABLE                                                     │
+│  ┌──┬────────────────┬──────────┬─────────┬──────┬─────┬──────┐│
+│  │☐ │ Lead Title     │ Client   │ Stage   │ Prio │Agent│ Date ││
+│  ├──┼────────────────┼──────────┼─────────┼──────┼─────┼──────┤│
+│  │☐ │ Villa interest │ Ahmed S. │ 🔵 New   │ 🔴   │Sara │ 2d  ││
+│  │☐ │ 3BR Apartment  │ Sara N.  │ 🟡 Contd│ 🟡   │Omar │ 5d  ││
+│  │☐ │ Office tour    │ Khaled O.│ 🟢 View │ 🟡   │Sara │ 1d  ││
+│  └──┴────────────────┴──────────┴─────────┴──────┴─────┴──────┘│
+│  Showing 1–10 of 42    [← Prev]  1  2  3 ... 5  [Next →]      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Pipeline Stages
+
+| Stage       | Color       | Description                        |
+|-------------|-------------|------------------------------------|
+| NEW         | Blue        | Freshly created, not yet contacted |
+| CONTACTED   | Cyan        | Initial outreach done              |
+| VIEWING     | Amber       | Property viewing scheduled/done    |
+| NEGOTIATION | Orange      | Price/terms negotiation in progress|
+| WON         | Green       | Deal closed, convert to contract   |
+| LOST        | Gray        | Lead dropped or chose competitor   |
+
+---
+
+## Component Spec
+
+### Header
+- Page title with chart icon (indigo)
+- Total leads count badge
+- `+ New Lead` button (primary)
+
+### Controls Row
+- Search bar (debounced 300ms, searches title + client name)
+- Priority filter dropdown: All / High / Medium / Low
+- Agent filter dropdown: All / [agent names from API]
+- View toggle: List (table icon) / Kanban (board icon)
+
+### Kanban Card
+```
+┌──────────────────────┐
+│ Villa Interest        │  ← title (bold, truncate 2 lines)
+│ 🔴 High  ·  🏠 Villa │  ← priority dot + property type
+│ 👤 Ahmed Samir       │  ← client name
+│ 🕐 2 days ago        │  ← relative timestamp
+│ Agent: Sara           │  ← assigned agent (small text)
+└──────────────────────┘
+```
+
+**Interactions:**
+- Click card → navigate to `/leads/:id`
+- Drag card between columns → PATCH `/api/leads/:id/stage`
+- Hover → subtle shadow elevation
+
+### Kanban Column
+- Column header: stage name + count badge
+- Scrollable vertically (max-height with overflow)
+- `+ Add` button at bottom of NEW column
+- Drop zone highlight (dashed indigo border) on drag-over
+
+### List Table Columns
+| Column     | Sortable | Notes                                        |
+|------------|----------|----------------------------------------------|
+| ☐          | —        | Bulk select checkbox                         |
+| Lead Title | ✓        | Title, clickable → detail page               |
+| Client     | ✓        | Client name, clickable → client detail       |
+| Stage      | ✓        | Colored badge matching pipeline stage         |
+| Priority   | ✓        | Dot indicator: 🔴 High, 🟡 Medium, 🟢 Low   |
+| Agent      | ✓        | Assigned agent name                          |
+| Created    | ✓        | Relative date                                |
+| Actions    | —        | Kebab: View, Edit, Change Stage, Delete      |
+
+### Bulk Actions (when rows selected)
+- `Change Stage` → dropdown with stages
+- `Assign Agent` → agent picker
+- `Delete` → confirm dialog
+
+---
+
+## States
+
+| State         | Display                                           |
+|---------------|---------------------------------------------------|
+| Loading       | Kanban: skeleton cards · List: skeleton rows       |
+| Empty         | "No leads yet" illustration + `+ New Lead` CTA    |
+| Empty column  | "No leads" ghost text in empty kanban column       |
+| Empty search  | "No leads matching '...'"                          |
+| Error         | Error card with retry button                       |
+| Dragging      | Card with drop shadow, origin faded                |
+
+---
+
+## Accessibility
+- Kanban columns use `role="list"`, cards use `role="listitem"`
+- Drag-and-drop has keyboard alternative: select card → arrow keys to move between columns
+- View toggle is a `role="radiogroup"` with `role="radio"` buttons
+- Stage change via drag announces to screen reader: "Moved {lead} to {stage}"
+- Priority indicators have `aria-label` (not just color)

--- a/src/clients/clients.controller.ts
+++ b/src/clients/clients.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   Param,
   ParseUUIDPipe,
-  Patch,
   Post,
   Put,
   Query,
@@ -82,12 +81,12 @@ export class ClientsController {
     return this.clientsService.remove(id);
   }
 
-  @Patch(':id/assign')
+  @Post(':id/assign-agent')
   @Roles('admin', 'manager')
   @ApiOperation({ summary: 'Assign client to an agent' })
   @ApiParam({ name: 'id', description: 'Client UUID' })
   @ApiResponse({ status: 200, description: 'Agent assigned' })
-  @ApiResponse({ status: 404, description: 'Client not found' })
+  @ApiResponse({ status: 404, description: 'Client or agent not found' })
   assignAgent(@Param('id', ParseUUIDPipe) id: string, @Body() dto: AssignAgentDto) {
     return this.clientsService.assignAgent(id, dto.agentId);
   }


### PR DESCRIPTION
## Issue #16 — Clients API: CRUD + Duplicate Detection + Agent Assignment

### Endpoints:
- **GET /api/clients** — List with filters, search, pagination
- **GET /api/clients/:id** — Get client with leads & contracts
- **POST /api/clients** — Create (with duplicate detection)
- **PUT /api/clients/:id** — Update (with duplicate detection on change)
- **DELETE /api/clients/:id** — Delete (admin only, checks for linked contracts)
- **POST /api/clients/:id/assign-agent** → body: `{ agentId: string }`

### Duplicate Detection:
- Before creating, checks if `phone` or `email` already exists
- Returns **409 Conflict** with descriptive message

### Access Control:
- All routes protected by JWT auth (global guard)
- Delete restricted to admin only
- Agent assignment restricted to admin/manager

### Changes:
- Renamed assign route from `PATCH :id/assign` to `POST :id/assign-agent` per spec
- Full Swagger documentation on all endpoints