### PR TITLE
fix: AuthMe BASE_URL http→https (#85, #91)

### DIFF
--- a/docker-compose.dev-server.yml
+++ b/docker-compose.dev-server.yml
@@ -42,7 +42,7 @@ services:
     environment:
       DATABASE_URL: postgresql://authme:authme@authme-db:5432/authme
       PORT: "3001"
-      BASE_URL: http://dev-auth.realstate-crm.homes
+      BASE_URL: https://dev-auth.realstate-crm.homes
       WEBHOOK_SECRET_KEY: dev-webhook-secret-6cc4fb3d383e0e3682dc013ffa533f1322c7cdea
       WEBHOOK_ENCRYPTION_SALT: dev-encryption-salt-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
     ports:


### PR DESCRIPTION
## Changes
- Changed AuthMe BASE_URL from http:// to https:// so OIDC discovery endpoints return correct HTTPS URLs
- Fixes #85 (OIDC endpoints return HTTP instead of HTTPS)  
- Fixes #91 (OIDC discovery URLs use http)

Nginx config changes for #81, #83, #86 were applied directly on server.