### PR TITLE
fix(#84): Swagger CSP connectSrc + server entries

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ async function bootstrap() {
           scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
           styleSrc: ["'self'", "'unsafe-inline'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
           imgSrc: ["'self'", 'data:', 'blob:', 'https://validator.swagger.io'],
-          connectSrc: ["'self'"],
+          connectSrc: ["'self'", 'https://dev-api.realstate-crm.homes'],
           fontSrc: ["'self'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
         },
       },
@@ -79,6 +79,8 @@ async function bootstrap() {
     .addTag('Property Images', 'Upload and manage property images')
     .addTag('Contract Documents', 'Upload contract documents')
     .addTag('File Serving', 'Serve uploaded files')
+    .addServer('https://dev-api.realstate-crm.homes', 'Dev')
+    .addServer('http://localhost:3000', 'Local')
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
Fixes #84

- Add dev API URL to CSP connectSrc so Swagger 'Try it out' is not blocked
- Add Dev and Local server entries to DocumentBuilder