### PR TITLE
fix(#90): JWT issuer mismatch — support AUTHME_ISSUER_URL

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -18,6 +18,11 @@ AUTHME_REALM=real-estate-dev
 # Backend client ID registered in AuthMe
 AUTHME_CLIENT_ID=crm-backend
 
+# Public issuer URL — the URL that Keycloak stamps into JWT `iss` claims.
+# Required when AUTHME_URL is an internal Docker hostname (e.g. http://authme:3001)
+# but tokens are issued with the public-facing URL.
+AUTHME_ISSUER_URL=https://dev-auth.realstate-crm.homes
+
 # Backend client secret (from AuthMe console → Clients → crm-backend → Credentials)
 # Get the secret by running: ./scripts/setup-authme-dev.sh
 # Or manually from: http://localhost:3001/console

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ AUTHME_URL=http://localhost:3001
 # Examples: real-estate-dev, real-estate-qa, real-estate-uat, real-estate
 AUTHME_REALM=real-estate
 
+# Public issuer URL — overrides AUTHME_URL for JWT issuer validation.
+# Set this when the internal AUTHME_URL differs from the public URL in JWT tokens.
+# Example: https://dev-auth.realstate-crm.homes
+# AUTHME_ISSUER_URL=
+
 # Backend client ID registered in AuthMe
 AUTHME_CLIENT_ID=crm-backend
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -31,12 +31,13 @@ import { RolesGuard } from './guards/roles.guard.js';
       useFactory: (config: ConfigService) => {
         const authmeUrl = config.getOrThrow<string>('AUTHME_URL');
         const realm = config.getOrThrow<string>('AUTHME_REALM');
+        const issuerBaseUrl = config.get<string>('AUTHME_ISSUER_URL') ?? authmeUrl;
         return {
           // The actual signing key is resolved via JWKS in the strategy.
           // We still configure the module so that @nestjs/jwt utilities work
           // when needed elsewhere (e.g., token introspection helpers).
           verifyOptions: {
-            issuer: `${authmeUrl}/realms/${realm}`,
+            issuer: `${issuerBaseUrl}/realms/${realm}`,
             algorithms: ['RS256'],
           },
         };

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -27,9 +27,13 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   ) {
     const authmeUrl = configService.getOrThrow<string>('AUTHME_URL');
     const realm = configService.getOrThrow<string>('AUTHME_REALM');
+    // AUTHME_ISSUER_URL overrides the base URL used for JWT issuer validation.
+    // This is needed when the internal AUTHME_URL (e.g. http://authme:3001) differs
+    // from the public URL that Keycloak stamps into tokens (e.g. https://dev-auth.realstate-crm.homes).
+    const issuerBaseUrl = configService.get<string>('AUTHME_ISSUER_URL') ?? authmeUrl;
 
     const jwksUri = `${authmeUrl}/realms/${realm}/protocol/openid-connect/certs`;
-    const issuer = `${authmeUrl}/realms/${realm}`;
+    const issuer = `${issuerBaseUrl}/realms/${realm}`;
 
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),


### PR DESCRIPTION
Fixes #90

When the backend runs inside Docker, AUTHME_URL points to the internal hostname
(e.g. http://authme:3001), but Keycloak stamps the public URL into JWT tokens
(e.g. https://dev-auth.realstate-crm.homes/realms/real-estate-dev).

This adds an optional AUTHME_ISSUER_URL env var that, when set, is used for
JWT issuer validation while AUTHME_URL continues to be used for JWKS key fetching.