### PR TITLE
fix(#94): unify API version from package.json

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,7 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { Public } from '../auth/decorators/public.decorator.js';
 import { PrismaService } from '../prisma/prisma.service.js';
+
+const pkg = JSON.parse(readFileSync(join(import.meta.dirname ?? '.', '..', 'package.json'), 'utf-8')) as { version: string };
 
 interface HealthResponse {
   status: 'ok' | 'degraded';
@@ -37,7 +41,7 @@ export class HealthController {
       timestamp: new Date().toISOString(),
       uptime: (Date.now() - this.startTime) / 1000,
       database: dbStatus,
-      version: process.env['npm_package_version'] ?? '0.0.1',
+      version: pkg.version,
     };
   }
 

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -5,7 +5,7 @@ import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { Public } from '../auth/decorators/public.decorator.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
-const pkg = JSON.parse(readFileSync(join(import.meta.dirname ?? '.', '..', 'package.json'), 'utf-8')) as { version: string };
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as { version: string };
 
 interface HealthResponse {
   status: 'ok' | 'degraded';

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { AppModule } from './app.module.js';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter.js';
 
 // Read version from package.json so Swagger and health endpoint stay in sync.
-const pkg = JSON.parse(readFileSync(join(import.meta.dirname ?? '.', '..', 'package.json'), 'utf-8')) as { version: string };
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as { version: string };
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -6,6 +8,9 @@ import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module.js';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter.js';
+
+// Read version from package.json so Swagger and health endpoint stay in sync.
+const pkg = JSON.parse(readFileSync(join(import.meta.dirname ?? '.', '..', 'package.json'), 'utf-8')) as { version: string };
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -62,7 +67,7 @@ async function bootstrap() {
         'Manages properties, clients, leads, contracts, invoices, and agent activities.\n\n' +
         'All protected endpoints require a Bearer token (JWT) from Authme IAM.',
     )
-    .setVersion('1.0.0')
+    .setVersion(pkg.version)
     .setContact('Real Estate CRM', '', '')
     .setLicense('Private', '')
     .addBearerAuth(


### PR DESCRIPTION
Fixes #94

Swagger showed version 1.0.0, health endpoint showed 0.0.1 — both now
read from package.json so they always match.