### PR TITLE
fix(authme): admin-cli + client secret sync (#97,#98)

### DIFF
--- a/docker-compose.dev-server.yml
+++ b/docker-compose.dev-server.yml
@@ -74,7 +74,7 @@ services:
       AUTHME_URL: http://crm-dev-authme:3001
       AUTHME_REALM: real-estate-dev
       AUTHME_CLIENT_ID: crm-backend
-      AUTHME_CLIENT_SECRET: dev-secret
+      AUTHME_CLIENT_SECRET: 43e7e6b59772f7c676920c42bbe8fa65c2213ea8e03926260cd5431a8d427087
       ADMIN_PORTAL_URL: http://dev-admin.realstate-crm.homes
       AGENT_PORTAL_URL: http://dev-agent.realstate-crm.homes
       UPLOAD_DIR: /app/uploads


### PR DESCRIPTION
## Fixes

### Bug #97 — admin-cli client missing from master realm
- Created admin-cli client (CONFIDENTIAL) in AuthMe master realm via admin API
- Grant types: client_credentials, password

### Bug #98 — crm-backend client_secret mismatch  
- Rotated crm-backend client secret (deleted + recreated client with fresh secret)
- Updated AUTHME_CLIENT_SECRET in docker-compose.dev-server.yml
- Updated GitHub secret AUTHME_CLIENT_SECRET

Fixes #97 #98