### PR TITLE
fix: email templates path + 404 sanitization filter ordering (#115,#117)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN npm run build
 # Copy UI build output into dist
 RUN cp -r admin-ui/dist dist/admin-ui
 RUN cp -r agent-ui/dist dist/agent-ui
+# Ensure email templates are alongside compiled email service
+RUN cp -r src/email/templates dist/src/email/templates 2>/dev/null || true
 
 # Stage 3: Production
 FROM node:24-alpine AS production

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -7,6 +7,7 @@
     "assets": [
       {
         "include": "email/templates/**/*.hbs",
+        "outDir": "dist/src",
         "watchAssets": true
       }
     ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,7 @@ async function bootstrap() {
   );
 
   // Global exception filters
-  app.useGlobalFilters(new SanitizeNotFoundFilter(), new HttpExceptionFilter());
+  app.useGlobalFilters(new HttpExceptionFilter(), new SanitizeNotFoundFilter());
 
   // Swagger / OpenAPI at /api/docs
   const config = new DocumentBuilder()


### PR DESCRIPTION
## Fixes
- **#117** Email templates not found: Dockerfile now copies templates to `dist/src/email/templates/` matching `__dirname` resolution. Also fixed `nest-cli.json` asset outDir.
- **#115/#122/#96** 404 path reflected: Swapped global filter registration order so `SanitizeNotFoundFilter` takes priority over `HttpExceptionFilter` for NotFoundException.