### PR TITLE
fix(auth): resolve all auth bugs #86,#90,#112,#113,#114,#119,#120,#121

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=admin-deps /app/admin-ui/node_modules ./admin-ui/node_modules
 COPY --from=agent-deps /app/agent-ui/node_modules ./agent-ui/node_modules
 COPY . .
-# Build UIs
+# Build UIs (Vite picks up .env.production files automatically)
 RUN cd admin-ui && npm run build
 RUN cd agent-ui && npm run build
 # Generate Prisma client and build NestJS

--- a/admin-ui/.env.production
+++ b/admin-ui/.env.production
@@ -1,0 +1,5 @@
+VITE_API_URL=https://dev-api.realstate-crm.homes
+VITE_AUTHME_URL=https://dev-auth.realstate-crm.homes
+VITE_AUTHME_REALM=real-estate-dev
+VITE_AUTHME_CLIENT_ID=admin-portal
+VITE_AUTHME_REDIRECT_URI=https://dev-admin.realstate-crm.homes/callback

--- a/agent-ui/.env.production
+++ b/agent-ui/.env.production
@@ -1,0 +1,5 @@
+VITE_API_URL=https://dev-api.realstate-crm.homes
+VITE_AUTHME_URL=https://dev-auth.realstate-crm.homes
+VITE_AUTHME_REALM=real-estate-dev
+VITE_AUTHME_CLIENT_ID=agent-portal
+VITE_AUTHME_REDIRECT_URI=https://dev-agent.realstate-crm.homes/callback

--- a/docker-compose.dev-server.yml
+++ b/docker-compose.dev-server.yml
@@ -72,6 +72,7 @@ services:
       # Connect to the standalone postgres-dev container via host network
       DATABASE_URL: postgresql://crm_user:real-estate-dev-password-123@host.docker.internal:5432/real_estate_crm_dev
       AUTHME_URL: http://crm-dev-authme:3001
+      AUTHME_ISSUER_URL: https://dev-auth.realstate-crm.homes
       AUTHME_REALM: real-estate-dev
       AUTHME_CLIENT_ID: crm-backend
       AUTHME_CLIENT_SECRET: 43e7e6b59772f7c676920c42bbe8fa65c2213ea8e03926260cd5431a8d427087

--- a/scripts/setup-authme-dev.sh
+++ b/scripts/setup-authme-dev.sh
@@ -225,22 +225,16 @@ create_user() {
     
     echo "  Creating user: $email"
     
-    # Create user
+    # Create user (AuthMe uses separate endpoints for user creation, password, and roles)
     USER_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$AUTHME_URL/admin/realms/$REALM_NAME/users" \
       -H "Authorization: Bearer $ADMIN_TOKEN" \
       -H "Content-Type: application/json" \
       -d '{
         "username": "'$email'",
         "email": "'$email'",
-        "emailVerified": true,
         "enabled": true,
         "firstName": "'$first_name'",
-        "lastName": "'$last_name'",
-        "credentials": [{
-            "type": "password",
-            "value": "'$password'",
-            "temporary": false
-        }]
+        "lastName": "'$last_name'"
       }')
     
     HTTP_CODE=$(echo "$USER_RESPONSE" | tail -n 1)

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -128,6 +128,60 @@ describe('JwtStrategy', () => {
       );
     });
 
+    it('should map unprefixed "admin" role to UserRole.ADMIN', async () => {
+      authService.syncUser.mockResolvedValue({
+        ...mockAuthenticatedUser,
+        role: UserRole.ADMIN,
+      });
+
+      const payload: JwtPayload = {
+        sub: 'authme-sub-123',
+        email: 'test@example.com',
+        realm_access: { roles: ['admin'] },
+      };
+
+      await strategy.validate(payload);
+
+      expect(authService.syncUser).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.ADMIN }),
+      );
+    });
+
+    it('should map unprefixed "manager" role to UserRole.MANAGER', async () => {
+      authService.syncUser.mockResolvedValue({
+        ...mockAuthenticatedUser,
+        role: UserRole.MANAGER,
+      });
+
+      const payload: JwtPayload = {
+        sub: 'authme-sub-123',
+        email: 'test@example.com',
+        realm_access: { roles: ['manager'] },
+      };
+
+      await strategy.validate(payload);
+
+      expect(authService.syncUser).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.MANAGER }),
+      );
+    });
+
+    it('should map unprefixed "agent" role to UserRole.AGENT', async () => {
+      authService.syncUser.mockResolvedValue(mockAuthenticatedUser);
+
+      const payload: JwtPayload = {
+        sub: 'authme-sub-123',
+        email: 'test@example.com',
+        realm_access: { roles: ['agent'] },
+      };
+
+      await strategy.validate(payload);
+
+      expect(authService.syncUser).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.AGENT }),
+      );
+    });
+
     it('should default to AGENT when no CRM roles are present', async () => {
       authService.syncUser.mockResolvedValue(mockAuthenticatedUser);
 

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -79,12 +79,18 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   /**
    * Maps Authme realm roles to the application UserRole enum.
    *
-   * Priority (highest first): crm-admin → crm-manager → crm-agent → AGENT (default)
+   * Supports both prefixed (crm-admin) and unprefixed (admin) role names
+   * so the backend works regardless of how the AuthMe realm roles are named.
+   *
+   * Priority (highest first): admin → manager → agent → AGENT (default)
    */
   private mapRole(realmRoles: string[]): UserRole {
-    if (realmRoles.includes('crm-admin')) return UserRole.ADMIN;
-    if (realmRoles.includes('crm-manager')) return UserRole.MANAGER;
-    if (realmRoles.includes('crm-agent')) return UserRole.AGENT;
+    if (realmRoles.includes('crm-admin') || realmRoles.includes('admin'))
+      return UserRole.ADMIN;
+    if (realmRoles.includes('crm-manager') || realmRoles.includes('manager'))
+      return UserRole.MANAGER;
+    if (realmRoles.includes('crm-agent') || realmRoles.includes('agent'))
+      return UserRole.AGENT;
     // Default to AGENT so any authenticated user can access the system
     return UserRole.AGENT;
   }


### PR DESCRIPTION
## Summary
Fixes all critical auth bugs that were breaking authentication.

### Changes

**Bug #113 — Realm roles mismatch (all users get AGENT)**
- Updated `mapRole()` in JwtStrategy to accept both prefixed (`crm-admin`) and unprefixed (`admin`) role names
- Added unit tests for unprefixed role mapping

**Bug #120 — AUTHME_ISSUER_URL not set**
- Added `AUTHME_ISSUER_URL: https://dev-auth.realstate-crm.homes` to docker-compose.dev-server.yml
- This also fixes **Bug #90** (JWT issuer mismatch)

**Bug #121 — Admin UI API calls go to localhost**
- Added `.env.production` files for both admin-ui and agent-ui
- Sets `VITE_API_URL=https://dev-api.realstate-crm.homes` and proper AuthMe URLs
- These are picked up automatically by Vite during production builds

**Bug #112 — JWT missing email/name claims**
- No code change needed; AuthMe SDK already requests `openid profile email` scopes
- Verified tokens include email, name, preferred_username when scopes are requested

**Bug #114 — Password grant rejects email login**
- Recreated test users with `username=email` via AuthMe admin API on server
- Updated setup script DTO format

**Bug #119 — OAuth2 code flow**
- Verified working correctly; login form carries OAuth params as hidden fields

**Bug #86 — AuthMe realm 404**
- `/realms/{name}` returns 404 but this is expected for AuthMe (not Keycloak)
- All functional endpoints work: OIDC discovery, JWKS, token, auth, login

### Server-side changes applied
- Recreated users: admin@test.com, manager@test.com, agent@test.com (with username=email)
- Assigned roles: admin, manager, agent respectively

### Test credentials
- admin@test.com / Admin123! (admin role)
- manager@test.com / Manager123! (manager role)
- agent@test.com / Agent123! (agent role)