### PR TITLE
feat(dashboard): Sprint 3 - Simplified dashboard endpoints

### DIFF
--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -7,6 +7,118 @@ import { DateRangeDto, DateRangePreset } from './dto/date-range.dto.js';
 export class DashboardService {
   constructor(private readonly prisma: PrismaService) {}
 
+  // ─── Simplified Endpoints (Sprint 3) ─────────────────────────────────
+
+  async getSimpleStats() {
+    const [totalProperties, totalClients, totalLeads, totalContracts, revenueResult] =
+      await Promise.all([
+        this.prisma.property.count(),
+        this.prisma.client.count(),
+        this.prisma.lead.count(),
+        this.prisma.contract.count(),
+        this.prisma.invoice.aggregate({
+          _sum: { amount: true },
+          where: { status: InvoiceStatus.PAID },
+        }),
+      ]);
+
+    return {
+      totalProperties,
+      totalClients,
+      totalLeads,
+      totalContracts,
+      revenue: Number(revenueResult._sum.amount ?? 0),
+    };
+  }
+
+  async getMonthlyRevenue(months = 6) {
+    const now = new Date();
+    const results: { month: string; revenue: number }[] = [];
+
+    for (let i = months - 1; i >= 0; i--) {
+      const start = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 0, 23, 59, 59, 999);
+      const label = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
+
+      const agg = await this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: {
+          status: InvoiceStatus.PAID,
+          paidDate: { gte: start, lte: end },
+        },
+      });
+
+      results.push({ month: label, revenue: Number(agg._sum.amount ?? 0) });
+    }
+
+    return results;
+  }
+
+  async getLeadsPipeline() {
+    const byStatus = await this.prisma.lead.groupBy({
+      by: ['status'],
+      _count: true,
+    });
+
+    return byStatus.map((g) => ({ stage: g.status, count: g._count }));
+  }
+
+  async getRecentActivities(limit = 10) {
+    return this.prisma.activity.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  }
+
+  async getTopAgentPerformance() {
+    const wonLeads = await this.prisma.lead.groupBy({
+      by: ['assignedAgentId'],
+      where: {
+        status: LeadStatus.WON,
+        assignedAgentId: { not: null },
+      },
+      _count: true,
+    });
+
+    const contracts = await this.prisma.contract.findMany({
+      where: {
+        status: { in: [ContractStatus.ACTIVE, ContractStatus.COMPLETED] },
+        agentId: { not: null },
+      },
+      select: { agentId: true, totalAmount: true },
+    });
+
+    const revenueByAgent: Record<string, number> = {};
+    for (const c of contracts) {
+      if (c.agentId) {
+        revenueByAgent[c.agentId] = (revenueByAgent[c.agentId] ?? 0) + Number(c.totalAmount);
+      }
+    }
+
+    const agentIds = new Set<string>();
+    wonLeads.forEach((w) => w.assignedAgentId && agentIds.add(w.assignedAgentId));
+    Object.keys(revenueByAgent).forEach((id) => agentIds.add(id));
+
+    const agents = await this.prisma.user.findMany({
+      where: { id: { in: Array.from(agentIds) } },
+      select: { id: true, firstName: true, lastName: true },
+    });
+
+    const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+    const results = Array.from(agentIds).map((agentId) => {
+      const agent = agentMap.get(agentId);
+      return {
+        agentId,
+        name: agent ? `${agent.firstName ?? ''} ${agent.lastName ?? ''}`.trim() : agentId,
+        dealsClosed: wonLeads.find((w) => w.assignedAgentId === agentId)?._count ?? 0,
+        revenue: revenueByAgent[agentId] ?? 0,
+      };
+    });
+
+    return results.sort((a, b) => b.dealsClosed - a.dealsClosed);
+  }
+
   // ─── Admin Endpoints ────────────────────────────────────────────────
 
   async getAdminOverview(dateRange: DateRangeDto) {


### PR DESCRIPTION
## Changes
- GET /api/dashboard/stats → totals for properties, clients, leads, contracts, revenue
- GET /api/dashboard/revenue?months=6 → monthly revenue data
- GET /api/dashboard/pipeline → leads count by stage
- GET /api/dashboard/recent-activity?limit=10 → latest activities
- GET /api/dashboard/agent-performance → top agents by deals closed