### PR TITLE
fix: QA bugs #144, #145, #146, #148, #149

### DIFF
--- a/src/clients/clients.controller.ts
+++ b/src/clients/clients.controller.ts
@@ -74,6 +74,7 @@ export class ClientsController {
     return this.clientsService.findOne(id);
   }
 
+  @Patch(':id')
   @Put(':id')
   @ApiOperation({ summary: 'Update a client' })
   @ApiParam({ name: 'id', description: 'Client UUID' })
@@ -94,6 +95,7 @@ export class ClientsController {
     return this.clientsService.remove(id);
   }
 
+  @Post(':id/assign')
   @Patch(':id/assign')
   @Roles('admin', 'manager')
   @ApiOperation({ summary: 'Assign client to an agent' })

--- a/src/common/interceptors/sanitize.interceptor.ts
+++ b/src/common/interceptors/sanitize.interceptor.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+/**
+ * Strips HTML/script tags from all string fields in the request body
+ * to prevent stored XSS attacks.
+ */
+@Injectable()
+export class SanitizeInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest();
+    if (request.body && typeof request.body === 'object') {
+      request.body = this.sanitize(request.body);
+    }
+    return next.handle();
+  }
+
+  private sanitize(value: unknown): unknown {
+    if (typeof value === 'string') {
+      return this.stripTags(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sanitize(item));
+    }
+    if (value !== null && typeof value === 'object') {
+      const sanitized: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(value)) {
+        sanitized[key] = this.sanitize(val);
+      }
+      return sanitized;
+    }
+    return value;
+  }
+
+  private stripTags(str: string): string {
+    // Remove all HTML tags including script, style, etc.
+    return str
+      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+      .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+      .replace(/<[^>]*>/g, '')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/<[^>]*>/g, '') // second pass after entity decode
+      .trim();
+  }
+}

--- a/src/contracts/contracts.controller.ts
+++ b/src/contracts/contracts.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Delete,
   Get,
   Post,
   Put,
@@ -76,6 +77,7 @@ export class ContractsController {
     return this.contractsService.findOne(id, user);
   }
 
+  @Patch(':id')
   @Put(':id')
   @Roles('admin', 'manager')
   @ApiOperation({ summary: 'Update a contract' })
@@ -88,6 +90,20 @@ export class ContractsController {
     @CurrentUser() user: AuthenticatedUser,
   ) {
     return this.contractsService.update(id, dto, user);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Delete a contract (admin only, only DRAFT/CANCELLED)' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiResponse({ status: 200, description: 'Contract deleted' })
+  @ApiResponse({ status: 400, description: 'Cannot delete active/completed contracts' })
+  @ApiResponse({ status: 404, description: 'Contract not found' })
+  remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.contractsService.remove(id, user);
   }
 
   @Patch(':id/status')

--- a/src/contracts/contracts.service.ts
+++ b/src/contracts/contracts.service.ts
@@ -201,6 +201,26 @@ export class ContractsService {
     });
   }
 
+  async remove(id: string, user: AuthenticatedUser) {
+    const contract = await this.prisma.contract.findUnique({ where: { id } });
+    if (!contract) {
+      throw new NotFoundException(`Contract ${id} not found`);
+    }
+
+    // Only allow deletion of DRAFT or CANCELLED contracts
+    if (
+      contract.status !== ContractStatus.DRAFT &&
+      contract.status !== ContractStatus.CANCELLED
+    ) {
+      throw new BadRequestException(
+        `Cannot delete contract in ${contract.status} status. Only DRAFT or CANCELLED contracts can be deleted.`,
+      );
+    }
+
+    await this.prisma.contract.delete({ where: { id } });
+    return { message: `Contract ${id} deleted successfully` };
+  }
+
   async changeStatus(id: string, dto: ChangeContractStatusDto, user: AuthenticatedUser) {
     const contract = await this.prisma.contract.findUnique({
       where: { id },

--- a/src/leads/leads.controller.ts
+++ b/src/leads/leads.controller.ts
@@ -90,6 +90,7 @@ export class LeadsController {
     return this.leadsService.findOne(id);
   }
 
+  @Patch(':id')
   @Put(':id')
   @ApiOperation({ summary: 'Update a lead' })
   @ApiParam({ name: 'id', description: 'Lead UUID' })
@@ -123,6 +124,7 @@ export class LeadsController {
     return this.leadsService.changeStatus(id, dto, user.id);
   }
 
+  @Post(':id/assign')
   @Patch(':id/assign')
   @Roles('admin', 'manager')
   @ApiOperation({ summary: 'Assign lead to an agent (admin/manager only)' })

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module.js';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter.js';
 import { SanitizeNotFoundFilter } from './common/filters/sanitize-not-found.filter.js';
+import { SanitizeInterceptor } from './common/interceptors/sanitize.interceptor.js';
 
 // Read version from package.json so Swagger and health endpoint stay in sync.
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')) as { version: string };
@@ -66,6 +67,9 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  // Global XSS sanitization interceptor
+  app.useGlobalInterceptors(new SanitizeInterceptor());
 
   // Global exception filters
   app.useGlobalFilters(new HttpExceptionFilter(), new SanitizeNotFoundFilter());

--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -78,6 +78,7 @@ export class PropertiesController {
     return this.propertiesService.findOne(id);
   }
 
+  @Patch(':id')
   @Put(':id')
   @ApiOperation({ summary: 'Update a property' })
   @ApiParam({ name: 'id', description: 'Property UUID' })
@@ -107,6 +108,7 @@ export class PropertiesController {
     return this.propertiesService.changeStatus(id, dto.status);
   }
 
+  @Post(':id/assign')
   @Patch(':id/assign')
   @Roles('admin', 'manager')
   @ApiOperation({ summary: 'Assign property to an agent' })


### PR DESCRIPTION
## QA Bug Fixes

### Bug #144 — PATCH returns 404 for update endpoints
Added `@Patch(':id')` alongside `@Put(':id')` on update methods in:
- `PropertiesController`
- `ClientsController`
- `LeadsController`
- `ContractsController`

### Bug #145 — Agent assignment endpoints 404 with POST
Added `@Post(':id/assign')` alongside `@Patch(':id/assign')` on assign methods in:
- `PropertiesController`
- `ClientsController`
- `LeadsController`

### Bug #146 — XSS: script tags stored unescaped
Created `SanitizeInterceptor` that recursively strips all HTML/script tags from string fields in request bodies. Registered globally in `main.ts`.

### Bug #148 — Contract DELETE missing
Added `DELETE /api/contracts/:id` endpoint (admin only). Restricted to DRAFT or CANCELLED contracts to prevent accidental deletion of active/completed contracts.

### Bug #149 — PENDING status missing from transitions
Regenerated Prisma client to include PENDING in ContractStatus enum. The migration and transition map already existed but the client was stale.