### PR TITLE
fix: QA bugs #154, #155, #156, #157, #158

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from './context/ThemeContext'
@@ -84,7 +84,11 @@ export default function App() {
                   <Route path="agents" element={<AgentsListPage />} />
                   <Route path="agents/:id" element={<AgentDetailPage />} />
                   <Route path="settings" element={<SettingsPage />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
                 </Route>
+
+                {/* Catch-all for routes outside the layout */}
+                <Route path="*" element={<Navigate to="/login" replace />} />
               </Routes>
             </ErrorBoundary>
 

--- a/agent-ui/src/App.tsx
+++ b/agent-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from './context/ThemeContext'
@@ -52,7 +52,11 @@ export default function App() {
                   <Route path="clients" element={<ClientsPage />} />
                   <Route path="contracts" element={<ContractsPage />} />
                   <Route path="activities" element={<ActivitiesPage />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
                 </Route>
+
+                {/* Catch-all for routes outside the layout */}
+                <Route path="*" element={<Navigate to="/login" replace />} />
               </Routes>
             </ErrorBoundary>
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,6 +6,9 @@ upstream nestjs {
     server app:3000;
 }
 
+# Hide Nginx version from Server header
+server_tokens off;
+
 # Rate limiting zone
 limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,9 @@ async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   // Security middleware — relax CSP for Swagger UI at /api/docs
+  // Build connectSrc from CORS origins so each environment allows its own API
+  const adminUrl = process.env['ADMIN_PORTAL_URL'] ?? 'http://localhost:5173';
+  const agentUrl = process.env['AGENT_PORTAL_URL'] ?? 'http://localhost:5174';
   app.use(
     helmet({
       contentSecurityPolicy: {
@@ -34,7 +37,7 @@ async function bootstrap() {
           ],
           styleSrc: ["'self'", "'unsafe-inline'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
           imgSrc: ["'self'", 'data:', 'blob:', 'https://validator.swagger.io'],
-          connectSrc: ["'self'", 'https://dev-api.realstate-crm.homes'],
+          connectSrc: ["'self'", adminUrl, agentUrl],
           fontSrc: ["'self'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
         },
       },
@@ -62,6 +65,11 @@ async function bootstrap() {
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
+  });
+
+  // Suppress favicon 404 errors (API server has no favicon)
+  app.use('/favicon.ico', (_req: import('express').Request, res: import('express').Response) => {
+    res.status(204).end();
   });
 
   // Cookie parser
@@ -111,8 +119,7 @@ async function bootstrap() {
     .addTag('Dashboard', 'Dashboard and analytics')
     .addTag('Email', 'Email service')
     .addTag('Uploads', 'File uploads')
-    .addServer('https://dev-api.realstate-crm.homes', 'Dev')
-    .addServer('http://localhost:3000', 'Local')
+    .addServer(`http://localhost:${process.env['PORT'] ?? 3000}`, 'Local')
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
## Summary
- **#154** — CSP `connect-src` was hardcoded to `dev-api` URL. Now reads from env vars (`ADMIN_PORTAL_URL`, `AGENT_PORTAL_URL`)
- **#155 + #156** — Admin UI and Agent UI showed blank pages on unmatched routes. Added `<Route path="*">` catch-all with proper redirects
- **#157** — API server returned 404 for `/favicon.ico`. Added 204 No Content handler
- **#158** — Nginx disclosed version in `Server` header. Added `server_tokens off` (also applied live on server)

## Test plan
- [ ] `curl -sI https://qa-api.realstate-crm.homes/api/health | grep Server` → shows `nginx` without version
- [ ] `curl -sI https://qa-api.realstate-crm.homes/favicon.ico` → returns 204, not 404
- [ ] Navigate to https://qa-admin.realstate-crm.homes/xyz → redirects to /login (not blank page)
- [ ] Navigate to https://qa-agent.realstate-crm.homes/xyz → redirects to /login (not blank page)
- [ ] CSP header on QA API uses qa-api URLs (not dev-api)

Closes #154, closes #155, closes #156, closes #157, closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)