### PR TITLE
Merge dev → QA: Fix CSP + favicon (#154, #157)

### DIFF
--- a/docker-compose.dev-server.yml
+++ b/docker-compose.dev-server.yml
@@ -76,8 +76,8 @@ services:
       AUTHME_REALM: real-estate-dev
       AUTHME_CLIENT_ID: crm-backend
       AUTHME_CLIENT_SECRET: 3d556405eb8c5aed1910239a59d548c195dc7a698f0aaa7b11e84a970eca2d7f
-      ADMIN_PORTAL_URL: http://dev-admin.realstate-crm.homes
-      AGENT_PORTAL_URL: http://dev-agent.realstate-crm.homes
+      ADMIN_PORTAL_URL: https://dev-admin.realstate-crm.homes
+      AGENT_PORTAL_URL: https://dev-agent.realstate-crm.homes
       UPLOAD_DIR: /app/uploads
       JWT_SECRET: dev-jwt-secret-change-in-prod
       REDIS_URL: redis://crm-dev-redis:6379

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -109,6 +109,13 @@ server {
         add_header Content-Type text/plain;
     }
 
+    # ── Suppress favicon 404 ──────────────────────────────────────────────
+    location = /favicon.ico {
+        return 204;
+        access_log off;
+        log_not_found off;
+    }
+
     # ── Deny dotfiles ───────────────────────────────────────────────────────
     location ~ /\. {
         deny all;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,9 +20,6 @@ async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   // Security middleware — relax CSP for Swagger UI at /api/docs
-  // Build connectSrc from CORS origins so each environment allows its own API
-  const adminUrl = process.env['ADMIN_PORTAL_URL'] ?? 'http://localhost:5173';
-  const agentUrl = process.env['AGENT_PORTAL_URL'] ?? 'http://localhost:5174';
   app.use(
     helmet({
       contentSecurityPolicy: {
@@ -37,7 +34,7 @@ async function bootstrap() {
           ],
           styleSrc: ["'self'", "'unsafe-inline'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
           imgSrc: ["'self'", 'data:', 'blob:', 'https://validator.swagger.io'],
-          connectSrc: ["'self'", adminUrl, agentUrl],
+          connectSrc: ["'self'"],
           fontSrc: ["'self'", 'https://unpkg.com', 'https://cdn.jsdelivr.net'],
         },
       },


### PR DESCRIPTION
## Summary
- **#154** — CSP `connect-src` now `'self'` only — no env-specific URLs leaked
- **#157** — Favicon returns 204 instead of 404

Verified on dev:
- `connect-src 'self'` ✅
- `/favicon.ico` → 204 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)