### PR TITLE
fix: seed test users in AuthMe on container start (#164)

### DIFF
--- a/authme-patches/entrypoint.sh
+++ b/authme-patches/entrypoint.sh
@@ -16,5 +16,10 @@ fi
 
 echo "[authme-patches] Applied hotfixes for #87, #92, #93"
 
+# Seed test users in background (non-production only, idempotent)
+if [ -f /patches/seed-users.sh ]; then
+  sh /patches/seed-users.sh &
+fi
+
 # Start the original entrypoint
 exec node dist/main

--- a/authme-patches/seed-users.sh
+++ b/authme-patches/seed-users.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Seed test users for non-production AuthMe realms
+# Runs in background after AuthMe starts — idempotent (skips if users exist)
+set -e
+
+ADMIN_PORT="${PORT:-3001}"
+BASE="http://localhost:${ADMIN_PORT}"
+REALM="${AUTHME_REALM:-real-estate-qa}"
+API_KEY="${ADMIN_API_KEY}"
+
+# Wait for AuthMe to be ready (up to 30s)
+echo "[seed-users] Waiting for AuthMe to be ready..."
+for i in $(seq 1 30); do
+  if wget -qO- "${BASE}/realms/${REALM}/.well-known/openid-configuration" >/dev/null 2>&1; then
+    echo "[seed-users] AuthMe is ready"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "[seed-users] AuthMe not ready after 30s — skipping seed"
+    exit 0
+  fi
+  sleep 1
+done
+
+# Helper: create user if not exists
+create_user() {
+  username="$1"
+  password="$2"
+  first="$3"
+  last="$4"
+  role="$5"
+
+  # Check if user exists
+  existing=$(wget -qO- \
+    --header="X-Admin-Api-Key: ${API_KEY}" \
+    "${BASE}/admin/realms/${REALM}/users?search=${username}" 2>/dev/null || echo '{"users":[],"total":0}')
+
+  if echo "$existing" | grep -q "\"username\":\"${username}\""; then
+    echo "[seed-users] User ${username} already exists — skipping"
+    return 0
+  fi
+
+  # Create user
+  response=$(wget -qO- \
+    --header="X-Admin-Api-Key: ${API_KEY}" \
+    --header="Content-Type: application/json" \
+    --post-data="{\"username\":\"${username}\",\"email\":\"${username}\",\"password\":\"${password}\",\"firstName\":\"${first}\",\"lastName\":\"${last}\",\"enabled\":true}" \
+    "${BASE}/admin/realms/${REALM}/users" 2>/dev/null || echo "FAILED")
+
+  if echo "$response" | grep -q "FAILED"; then
+    echo "[seed-users] Failed to create ${username}"
+    return 1
+  fi
+
+  echo "[seed-users] Created user: ${username}"
+}
+
+# Seed test users
+create_user "admin@crm.test"   "Admin@123!" "QA" "Admin"   "admin"
+create_user "agent@crm.test"   "Agent@123!" "QA" "Agent"   "agent"
+create_user "manager@crm.test" "Manager@123!" "QA" "Manager" "manager"
+
+echo "[seed-users] Seeding complete"


### PR DESCRIPTION
Fixes #164

- Added `authme-patches/seed-users.sh` — idempotent script that seeds admin@crm.test, agent@crm.test, manager@crm.test after AuthMe starts
- Updated entrypoint.sh to run the seed script in the background on container start
- Script waits up to 30s for AuthMe to be ready, skips if users already exist