### PR TITLE
fix: add minWidth/minHeight to ResponsiveContainer (#167)

### DIFF
--- a/admin-ui/src/components/dashboard/LeadsPipelineChart.tsx
+++ b/admin-ui/src/components/dashboard/LeadsPipelineChart.tsx
@@ -95,7 +95,7 @@ export function LeadsPipelineChart({ data, isLoading }: Props) {
       <div className="h-64">
         {pipeline.length ? (
           mode === 'donut' ? (
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
               <PieChart>
                 <Pie
                   data={pipeline}
@@ -129,7 +129,7 @@ export function LeadsPipelineChart({ data, isLoading }: Props) {
               </PieChart>
             </ResponsiveContainer>
           ) : (
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
               <BarChart data={pipeline} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
                 <XAxis

--- a/admin-ui/src/components/dashboard/PropertiesCharts.tsx
+++ b/admin-ui/src/components/dashboard/PropertiesCharts.tsx
@@ -53,7 +53,7 @@ export function PropertiesCharts({ data, isLoading }: Props) {
           </p>
           <div className="h-52">
             {byStatus.length ? (
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                 <PieChart>
                   <Pie
                     data={byStatus}
@@ -93,7 +93,7 @@ export function PropertiesCharts({ data, isLoading }: Props) {
           </p>
           <div className="h-52">
             {byType.length ? (
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                 <PieChart>
                   <Pie
                     data={byType}

--- a/admin-ui/src/components/dashboard/RevenueChart.tsx
+++ b/admin-ui/src/components/dashboard/RevenueChart.tsx
@@ -61,7 +61,7 @@ export function RevenueChart({ data, isLoading }: Props) {
     >
       <div className="h-64">
         {data?.timeline.length ? (
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
             <AreaChart data={data.timeline} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
               <defs>
                 <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">

--- a/admin-ui/src/pages/reports/ReportsPage.tsx
+++ b/admin-ui/src/pages/reports/ReportsPage.tsx
@@ -191,7 +191,7 @@ export default function ReportsPage() {
               <Skeleton height="h-72" />
             ) : revenue.data?.data?.length ? (
               <div className="h-72">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                   <AreaChart data={revenue.data.data} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
                     <defs>
                       <linearGradient id="reportRevenueGrad" x1="0" y1="0" x2="0" y2="1">
@@ -235,7 +235,7 @@ export default function ReportsPage() {
               <Skeleton height="h-64" />
             ) : revenue.data?.data?.length ? (
               <div className="h-64">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                   <BarChart data={revenue.data.data} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
                     <XAxis dataKey="period" tick={{ fontSize: 11 }} />
@@ -314,7 +314,7 @@ export default function ReportsPage() {
                 <Skeleton height="h-64" />
               ) : leadConversion.data?.bySource?.length ? (
                 <div className="h-64">
-                  <ResponsiveContainer width="100%" height="100%">
+                  <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                     <BarChart
                       data={leadConversion.data.bySource}
                       layout="vertical"
@@ -350,7 +350,7 @@ export default function ReportsPage() {
                 <Skeleton height="h-64" />
               ) : leadConversion.data?.bySource?.length ? (
                 <div className="h-64">
-                  <ResponsiveContainer width="100%" height="100%">
+                  <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                     <PieChart>
                       <Pie
                         data={leadConversion.data.bySource}
@@ -461,7 +461,7 @@ export default function ReportsPage() {
                 <Skeleton height="h-64" />
               ) : propertyReport.data?.byType?.length ? (
                 <div className="h-64">
-                  <ResponsiveContainer width="100%" height="100%">
+                  <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                     <BarChart data={propertyReport.data.byType} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
                       <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
                       <XAxis dataKey="type" tick={{ fontSize: 11 }} />
@@ -494,7 +494,7 @@ export default function ReportsPage() {
                 <Skeleton height="h-64" />
               ) : propertyReport.data?.byType?.length ? (
                 <div className="h-64">
-                  <ResponsiveContainer width="100%" height="100%">
+                  <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
                     <PieChart>
                       <Pie
                         data={propertyReport.data.byType}

--- a/agent-ui/src/pages/DashboardPage.tsx
+++ b/agent-ui/src/pages/DashboardPage.tsx
@@ -230,7 +230,7 @@ function LeadPipelineSection({
           <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
             Pipeline Distribution
           </p>
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
             <BarChart data={chartData} barSize={28}>
               <XAxis
                 dataKey="name"
@@ -266,7 +266,7 @@ function LeadPipelineSection({
           <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
             Status Breakdown
           </p>
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
             <PieChart>
               <Pie
                 data={pieData}
@@ -505,7 +505,7 @@ function PerformanceSection({
       </div>
 
       <div className="h-48">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
           <BarChart data={barData} barGap={4} barSize={24}>
             <XAxis dataKey="name" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
             <YAxis allowDecimals={false} tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />


### PR DESCRIPTION
Fixes #167

Added minWidth={0} minHeight={0} to all ResponsiveContainer components across admin-ui and agent-ui to prevent negative dimension warnings during initial layout.