### PR TITLE
fix: remap pageSize to limit in API interceptor (#168)

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -10,12 +10,17 @@ export const apiClient = axios.create({
   },
 })
 
-// Request interceptor — inject Bearer token from AuthMe SDK
+// Request interceptor — inject Bearer token + remap pageSize→limit
 apiClient.interceptors.request.use(
   (config) => {
     const token = authme.getAccessToken()
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
+    }
+    // API uses 'limit' not 'pageSize' for pagination
+    if (config.params?.pageSize != null) {
+      config.params.limit = config.params.pageSize
+      delete config.params.pageSize
     }
     return config
   },

--- a/agent-ui/src/api/client.ts
+++ b/agent-ui/src/api/client.ts
@@ -10,12 +10,17 @@ export const apiClient = axios.create({
   },
 })
 
-// Request interceptor — inject Bearer token from AuthMe SDK
+// Request interceptor — inject Bearer token + remap pageSize→limit
 apiClient.interceptors.request.use(
   (config) => {
     const token = authme.getAccessToken()
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
+    }
+    // API uses 'limit' not 'pageSize' for pagination
+    if (config.params?.pageSize != null) {
+      config.params.limit = config.params.pageSize
+      delete config.params.pageSize
     }
     return config
   },


### PR DESCRIPTION
Fixes #168

Frontend uses pageSize but API expects limit. Added axios request interceptor in both admin-ui and agent-ui to remap pageSize→limit globally for all API calls.