### PR TITLE
fix: retry with token refresh on 401 before redirecting to login (#169)

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -27,11 +27,40 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error),
 )
 
-// Response interceptor — handle 401
+// Response interceptor — attempt token refresh on 401 before redirecting
+let isRefreshing = false
+let pendingRequests: ((token: string) => void)[] = []
+
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
+  async (error) => {
+    const original = error.config
+    if (error.response?.status === 401 && !original._retry) {
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          pendingRequests.push((token) => {
+            original.headers.Authorization = `Bearer ${token}`
+            resolve(apiClient(original))
+          })
+        })
+      }
+      original._retry = true
+      isRefreshing = true
+      try {
+        const refreshed = await authme.refreshTokens()
+        if (refreshed) {
+          const newToken = authme.getAccessToken()!
+          pendingRequests.forEach((cb) => cb(newToken))
+          pendingRequests = []
+          isRefreshing = false
+          original.headers.Authorization = `Bearer ${newToken}`
+          return apiClient(original)
+        }
+      } catch {
+        // refresh failed
+      }
+      isRefreshing = false
+      pendingRequests = []
       window.location.href = '/login'
     }
     return Promise.reject(error)

--- a/agent-ui/src/api/client.ts
+++ b/agent-ui/src/api/client.ts
@@ -27,11 +27,40 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error),
 )
 
-// Response interceptor — handle 401
+// Response interceptor — attempt token refresh on 401 before redirecting
+let isRefreshing = false
+let pendingRequests: ((token: string) => void)[] = []
+
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
+  async (error) => {
+    const original = error.config
+    if (error.response?.status === 401 && !original._retry) {
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          pendingRequests.push((token) => {
+            original.headers.Authorization = `Bearer ${token}`
+            resolve(apiClient(original))
+          })
+        })
+      }
+      original._retry = true
+      isRefreshing = true
+      try {
+        const refreshed = await authme.refreshTokens()
+        if (refreshed) {
+          const newToken = authme.getAccessToken()!
+          pendingRequests.forEach((cb) => cb(newToken))
+          pendingRequests = []
+          isRefreshing = false
+          original.headers.Authorization = `Bearer ${newToken}`
+          return apiClient(original)
+        }
+      } catch {
+        // refresh failed
+      }
+      isRefreshing = false
+      pendingRequests = []
       window.location.href = '/login'
     }
     return Promise.reject(error)


### PR DESCRIPTION
Fixes #169

Instead of immediately redirecting to /login on 401, the interceptor now attempts to refresh the token first via authme.refreshTokens(). Only redirects to login if refresh fails. Also queues concurrent requests during refresh to avoid race conditions.