### PR TITLE
fix: add users and settings API endpoints (#171)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,8 @@ import { DashboardModule } from './dashboard/dashboard.module.js';
 import { EmailModule } from './email/email.module.js';
 import { HealthModule } from './health/health.module.js';
 import { ReportsModule } from './reports/reports.module.js';
+import { UsersModule } from './users/users.module.js';
+import { SettingsModule } from './settings/settings.module.js';
 
 @Module({
   imports: [
@@ -44,6 +46,8 @@ import { ReportsModule } from './reports/reports.module.js';
     EmailModule,
     HealthModule,
     ReportsModule,
+    UsersModule,
+    SettingsModule,
   ],
   providers: [
     // Rate limiting — applied first, before auth

--- a/src/settings/settings.controller.ts
+++ b/src/settings/settings.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Put, Body, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SettingsService } from './settings.service.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('Settings')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Roles('admin')
+@Controller('api/settings')
+export class SettingsController {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  @Get('company')
+  @ApiOperation({ summary: 'Get company settings' })
+  getCompany() {
+    return this.settingsService.get('company');
+  }
+
+  @Put('company')
+  @ApiOperation({ summary: 'Update company settings' })
+  updateCompany(@Body() data: Record<string, unknown>) {
+    return this.settingsService.set('company', data);
+  }
+
+  @Get('property-types')
+  @ApiOperation({ summary: 'Get property type config' })
+  getPropertyTypes() {
+    return this.settingsService.get('property-types');
+  }
+
+  @Put('property-types')
+  @ApiOperation({ summary: 'Update property type config' })
+  updatePropertyTypes(@Body('items') items: unknown[]) {
+    return this.settingsService.set('property-types', items);
+  }
+
+  @Get('lead-sources')
+  @ApiOperation({ summary: 'Get lead source config' })
+  getLeadSources() {
+    return this.settingsService.get('lead-sources');
+  }
+
+  @Put('lead-sources')
+  @ApiOperation({ summary: 'Update lead source config' })
+  updateLeadSources(@Body('items') items: unknown[]) {
+    return this.settingsService.set('lead-sources', items);
+  }
+}

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SettingsController } from './settings.controller.js';
+import { SettingsService } from './settings.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SettingsController],
+  providers: [SettingsService],
+})
+export class SettingsModule {}

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+@Injectable()
+export class SettingsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async get(key: string) {
+    const setting = await this.prisma.setting.findUnique({ where: { key } });
+    return setting?.value ?? {};
+  }
+
+  async set(key: string, value: unknown) {
+    const result = await this.prisma.setting.upsert({
+      where: { key },
+      update: { value: value as never },
+      create: { key, value: value as never },
+    });
+    return result.value;
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Query,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UsersService } from './users.service.js';
+import { Roles } from '../common/decorators/roles.decorator.js';
+import { AuthGuard } from '../common/guards/auth.guard.js';
+
+@ApiTags('Users')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller('api/users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'List users with optional role filter' })
+  list(
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('search') search?: string,
+    @Query('role') role?: string,
+  ) {
+    return this.usersService.list({
+      page: page ? parseInt(page, 10) : 1,
+      limit: limit ? parseInt(limit, 10) : 10,
+      search,
+      role,
+    });
+  }
+
+  @Get(':id')
+  @Roles('admin', 'manager')
+  @ApiOperation({ summary: 'Get user detail with assignments' })
+  getById(@Param('id') id: string) {
+    return this.usersService.getById(id);
+  }
+
+  @Patch(':id/status')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Toggle user active status' })
+  toggleActive(@Param('id') id: string, @Body('isActive') isActive: boolean) {
+    return this.usersService.toggleActive(id, isActive);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller.js';
+import { UsersService } from './users.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+interface ListParams {
+  page: number;
+  limit: number;
+  search?: string;
+  role?: string;
+}
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(params: ListParams) {
+    const { page, limit, search, role } = params;
+    const skip = (page - 1) * limit;
+
+    const where = {
+      ...(role ? { role: role as UserRole } : {}),
+      ...(search
+        ? {
+            OR: [
+              { email: { contains: search, mode: 'insensitive' as const } },
+              { firstName: { contains: search, mode: 'insensitive' as const } },
+              { lastName: { contains: search, mode: 'insensitive' as const } },
+            ],
+          }
+        : {}),
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          _count: {
+            select: {
+              assignedProperties: true,
+              assignedClients: true,
+              assignedLeads: true,
+            },
+          },
+        },
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async getById(id: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      include: {
+        assignedProperties: {
+          select: { id: true, title: true, status: true, price: true, type: true },
+          take: 50,
+        },
+        assignedClients: {
+          select: { id: true, firstName: true, lastName: true, email: true, phone: true },
+          take: 50,
+        },
+        assignedLeads: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            priority: true,
+            source: true,
+            createdAt: true,
+          },
+          take: 50,
+        },
+        _count: {
+          select: {
+            assignedProperties: true,
+            assignedClients: true,
+            assignedLeads: true,
+          },
+        },
+      },
+    });
+
+    if (!user) throw new NotFoundException('User not found');
+
+    // Compute performance metrics
+    const [leadsWon, revenueResult] = await Promise.all([
+      this.prisma.lead.count({
+        where: { agentId: id, status: 'WON' },
+      }),
+      this.prisma.invoice.aggregate({
+        _sum: { amount: true },
+        where: {
+          status: 'PAID',
+          contract: { agentId: id },
+        },
+      }),
+    ]);
+
+    const totalLeads = user._count.assignedLeads;
+    const revenue = Number(revenueResult._sum.amount ?? 0);
+
+    return {
+      ...user,
+      performance: {
+        totalLeads,
+        leadsWon,
+        revenue,
+        conversionRate: totalLeads > 0 ? (leadsWon / totalLeads) * 100 : 0,
+      },
+    };
+  }
+
+  async toggleActive(id: string, isActive: boolean) {
+    return this.prisma.user.update({
+      where: { id },
+      data: { isActive },
+    });
+  }
+}


### PR DESCRIPTION
Fixes #171

Created UsersModule (GET /api/users, GET /api/users/:id, PATCH /api/users/:id/status) and SettingsModule (GET/PUT /api/settings/company, property-types, lead-sources) to match frontend expectations.

Reports endpoints were already added in #170.