### PR TITLE
fix: add mobile responsive sidebar to agent-ui (#185)

### DIFF
--- a/agent-ui/src/components/layout/Layout.tsx
+++ b/agent-ui/src/components/layout/Layout.tsx
@@ -1,17 +1,80 @@
-import { useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Outlet, useLocation } from 'react-router-dom'
+import { Menu } from 'lucide-react'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
 
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false,
+  )
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+    const handler = (e: MediaQueryListEvent | MediaQueryList) => setIsMobile(e.matches)
+    handler(mq)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [breakpoint])
+  return isMobile
+}
+
 export function Layout() {
-  const [collapsed, setCollapsed] = useState(false)
+  const isMobile = useIsMobile()
+  const [collapsed, setCollapsed] = useState(isMobile)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const location = useLocation()
+
+  useEffect(() => {
+    if (isMobile) {
+      setCollapsed(true)
+      setMobileOpen(false)
+    }
+  }, [isMobile])
+
+  useEffect(() => {
+    if (isMobile) setMobileOpen(false)
+  }, [location.pathname, isMobile])
 
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-950">
-      <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
+      {isMobile && mobileOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/40"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
+      <div
+        className={
+          isMobile
+            ? `fixed inset-y-0 left-0 z-40 transition-transform duration-300 ${
+                mobileOpen ? 'translate-x-0' : '-translate-x-full'
+              }`
+            : ''
+        }
+      >
+        <Sidebar
+          collapsed={isMobile ? false : collapsed}
+          onToggle={() => {
+            if (isMobile) setMobileOpen(false)
+            else setCollapsed((c) => !c)
+          }}
+        />
+      </div>
+
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-        <TopBar />
-        <main className="flex-1 overflow-y-auto p-6">
+        <TopBar>
+          {isMobile && (
+            <button
+              onClick={() => setMobileOpen((o) => !o)}
+              className="mr-2 p-1.5 rounded-lg text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Toggle menu"
+            >
+              <Menu size={20} />
+            </button>
+          )}
+        </TopBar>
+        <main className="flex-1 overflow-y-auto p-4 md:p-6">
           <Outlet />
         </main>
       </div>

--- a/agent-ui/src/components/layout/TopBar.tsx
+++ b/agent-ui/src/components/layout/TopBar.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '../../context/ThemeContext'
 import { Breadcrumbs } from './Breadcrumbs'
 import { cn, getInitials } from '../../utils'
 
-export function TopBar() {
+export function TopBar({ children }: { children?: React.ReactNode }) {
   const { user, logout } = useAuth()
   const { theme, toggleTheme } = useTheme()
   const [dropdownOpen, setDropdownOpen] = useState(false)
@@ -23,7 +23,8 @@ export function TopBar() {
   }, [])
 
   return (
-    <header className="flex items-center h-16 px-6 gap-4 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700/60 shrink-0">
+    <header className="flex items-center h-16 px-4 md:px-6 gap-4 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700/60 shrink-0">
+      {children}
       {/* Breadcrumbs */}
       <div className="flex-1 min-w-0">
         <Breadcrumbs />


### PR DESCRIPTION
Fixes #185

Applied the same mobile responsive sidebar pattern from admin-ui to agent-ui:
- Auto-collapse sidebar on viewports < 768px
- Sidebar opens as overlay with backdrop on mobile
- Hamburger menu button in TopBar
- Closes on route navigation