### PR TITLE
fix: correct Prisma field names in reports/users modules (#182)

### DIFF
--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -83,7 +83,7 @@ export class ReportsService {
       paidDate: { gte: start, lte: end },
     };
     if (params.agentId) {
-      where.contract = { property: { agentId: params.agentId } };
+      where.contract = { property: { assignedAgentId: params.agentId } };
     }
 
     const invoices = await this.prisma.invoice.findMany({
@@ -123,7 +123,7 @@ export class ReportsService {
     const where: Prisma.LeadWhereInput = {
       createdAt: { gte: start, lte: end },
     };
-    if (params.agentId) where.agentId = params.agentId;
+    if (params.agentId) where.assignedAgentId = params.agentId;
     if (params.source) where.source = params.source;
 
     const leads = await this.prisma.lead.findMany({

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -82,7 +82,6 @@ export class UsersService {
         assignedLeads: {
           select: {
             id: true,
-            title: true,
             status: true,
             priority: true,
             source: true,
@@ -90,23 +89,17 @@ export class UsersService {
           },
           take: 50,
         },
-        _count: {
-          select: {
-            assignedProperties: true,
-            assignedClients: true,
-            assignedLeads: true,
-          },
-        },
       },
     });
 
     if (!user) throw new NotFoundException('User not found');
 
-    const totalLeads: number = user._count.assignedLeads;
-
-    const [leadsWon, revenueResult] = await Promise.all([
+    const [totalLeads, leadsWon, revenueResult] = await Promise.all([
       this.prisma.lead.count({
-        where: { agentId: id, status: LeadStatus.WON },
+        where: { assignedAgentId: id },
+      }),
+      this.prisma.lead.count({
+        where: { assignedAgentId: id, status: LeadStatus.WON },
       }),
       this.prisma.invoice.aggregate({
         _sum: { amount: true },


### PR DESCRIPTION
Fixes #182

- Changed `agentId` to `assignedAgentId` in Lead/Property queries (matching Prisma schema)
- Removed nonexistent `title` from Lead select
- Replaced `_count.assignedLeads` with separate count query to avoid type resolution issues