### PR TITLE
test(#60, #61): E2E tests for clients, leads, contracts, invoices

### DIFF
--- a/e2e/clients-leads.spec.ts
+++ b/e2e/clients-leads.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * E2E Tests: Client Management + Lead Pipeline — Real Estate CRM
+ * Issue: #60 (M3-7)
+ *
+ * Tests UI page loading and API security boundaries.
+ * Authenticated CRUD is covered by API integration tests (test/*.integration.spec.ts).
+ */
+
+import { test, expect, request } from '@playwright/test';
+import { ADMIN_URL, API_URL } from './fixtures/index.js';
+
+// ─── Clients UI Tests ────────────────────────────────────────────────────────
+
+test.describe('Admin Portal — Clients page', () => {
+  test('Clients route redirects to login when unauthenticated', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    await page.goto(`${ADMIN_URL}/clients`);
+    await page.waitForLoadState('networkidle');
+
+    const url = page.url();
+    const isProtected = url.includes('/login') || url.includes('auth');
+    expect(isProtected).toBeTruthy();
+    await context.close();
+  });
+});
+
+// ─── Leads UI Tests ──────────────────────────────────────────────────────────
+
+test.describe('Admin Portal — Leads page', () => {
+  test('Leads route redirects to login when unauthenticated', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    await page.goto(`${ADMIN_URL}/leads`);
+    await page.waitForLoadState('networkidle');
+
+    const url = page.url();
+    const isProtected = url.includes('/login') || url.includes('auth');
+    expect(isProtected).toBeTruthy();
+    await context.close();
+  });
+});
+
+// ─── API Security Boundary Tests ─────────────────────────────────────────────
+
+test.describe('API — Clients & Leads (no-auth boundary)', () => {
+  test('GET /clients without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/clients')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('POST /clients without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.post('/clients', { data: { firstName: 'Test' } })).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('DELETE /clients/:id without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.delete('/clients/00000000-0000-0000-0000-000000000000')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /leads without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/leads')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /leads/pipeline without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/leads/pipeline')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /leads/stats without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/leads/stats')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('POST /leads without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.post('/leads', { data: {} })).status()).toBe(401);
+    await ctx.dispose();
+  });
+});

--- a/e2e/contracts.spec.ts
+++ b/e2e/contracts.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * E2E Tests: Contract Workflow + Invoices — Real Estate CRM
+ * Issue: #61 (M3-8)
+ *
+ * Tests UI page loading and API security boundaries.
+ * Authenticated CRUD is covered by API integration tests (test/*.integration.spec.ts).
+ */
+
+import { test, expect, request } from '@playwright/test';
+import { ADMIN_URL, API_URL } from './fixtures/index.js';
+
+// ─── Contracts UI Tests ──────────────────────────────────────────────────────
+
+test.describe('Admin Portal — Contracts page', () => {
+  test('Contracts route redirects to login when unauthenticated', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    await page.goto(`${ADMIN_URL}/contracts`);
+    await page.waitForLoadState('networkidle');
+
+    const url = page.url();
+    const isProtected = url.includes('/login') || url.includes('auth');
+    expect(isProtected).toBeTruthy();
+    await context.close();
+  });
+});
+
+// ─── Invoices UI Tests ───────────────────────────────────────────────────────
+
+test.describe('Admin Portal — Invoices page', () => {
+  test('Invoices route redirects to login when unauthenticated', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    await page.goto(`${ADMIN_URL}/invoices`);
+    await page.waitForLoadState('networkidle');
+
+    const url = page.url();
+    const isProtected = url.includes('/login') || url.includes('auth');
+    expect(isProtected).toBeTruthy();
+    await context.close();
+  });
+});
+
+// ─── API Security Boundary Tests ─────────────────────────────────────────────
+
+test.describe('API — Contracts & Invoices (no-auth boundary)', () => {
+  test('GET /contracts without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/contracts')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('POST /contracts without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.post('/contracts', { data: {} })).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /contracts/stats without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/contracts/stats')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /contracts/expiring without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/contracts/expiring')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /invoices without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/invoices')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /invoices/stats without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/invoices/stats')).status()).toBe(401);
+    await ctx.dispose();
+  });
+
+  test('GET /invoices/overdue without auth returns 401', async () => {
+    const ctx = await request.newContext({ baseURL: API_URL });
+    expect((await ctx.get('/invoices/overdue')).status()).toBe(401);
+    await ctx.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- Route protection E2E tests (unauthenticated → redirect to login)
- API security boundary tests (all endpoints return 401 without auth)
- Covers: Clients, Leads (pipeline, stats), Contracts (stats, expiring), Invoices (overdue, stats)

Closes #60, closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)