### PR TITLE
security: remove hardcoded production secrets from docker-compose files (#210)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,18 @@
+# ==============================================================================
+# Real Estate CRM — Production Environment Variables
+# ==============================================================================
+# COPY THIS FILE TO .env.prod AND FILL IN REAL VALUES
+# DO NOT COMMIT .env.prod TO VERSION CONTROL
+
+# ── AuthMe PostgreSQL ────────────────────────────────────────────────────────
+POSTGRES_PASSWORD=
+
+# ── AuthMe IAM ───────────────────────────────────────────────────────────────
+ADMIN_API_KEY=
+WEBHOOK_SECRET_KEY=
+WEBHOOK_ENCRYPTION_SALT=
+
+# ── NestJS Backend ───────────────────────────────────────────────────────────
+DB_PASSWORD=
+AUTHME_CLIENT_SECRET=
+JWT_SECRET=

--- a/.env.qa.example
+++ b/.env.qa.example
@@ -1,0 +1,18 @@
+# ==============================================================================
+# Real Estate CRM — QA Environment Variables
+# ==============================================================================
+# COPY THIS FILE TO .env.qa AND FILL IN REAL VALUES
+# DO NOT COMMIT .env.qa TO VERSION CONTROL
+
+# ── AuthMe PostgreSQL ────────────────────────────────────────────────────────
+POSTGRES_PASSWORD=
+
+# ── AuthMe IAM ──────────────────────────────────────────────────────────────
+ADMIN_API_KEY=
+WEBHOOK_SECRET_KEY=
+WEBHOOK_ENCRYPTION_SALT=
+
+# ── NestJS Backend ─────────────────────────────────────────────────────────
+DB_PASSWORD=
+AUTHME_CLIENT_SECRET=
+JWT_SECRET=

--- a/.env.uat.example
+++ b/.env.uat.example
@@ -1,0 +1,18 @@
+# ==============================================================================
+# Real Estate CRM — UAT Environment Variables
+# ==============================================================================
+# COPY THIS FILE TO .env.uat AND FILL IN REAL VALUES
+# DO NOT COMMIT .env.uat TO VERSION CONTROL
+
+# ── AuthMe PostgreSQL ────────────────────────────────────────────────────────
+POSTGRES_PASSWORD=
+
+# ── AuthMe IAM ───────────────────────────────────────────────────────────────
+ADMIN_API_KEY=
+WEBHOOK_SECRET_KEY=
+WEBHOOK_ENCRYPTION_SALT=
+
+# ── NestJS Backend ──────────────────────────────────────────────────────────
+DB_PASSWORD=
+AUTHME_CLIENT_SECRET=
+JWT_SECRET=

--- a/docker-compose.prod-server.yml
+++ b/docker-compose.prod-server.yml
@@ -12,7 +12,7 @@ services:
     container_name: crm-prod-authme-db
     environment:
       POSTGRES_USER: authme
-      POSTGRES_PASSWORD: authme-prod-secure-change-me
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in env}
       POSTGRES_DB: authme_prod
     volumes:
       - authme-pgdata-prod:/var/lib/postgresql/data
@@ -30,14 +30,14 @@ services:
     restart: unless-stopped
     container_name: crm-prod-authme
     environment:
-      DATABASE_URL: postgresql://authme:authme-prod-secure-change-me@authme-db:5432/authme_prod
+      DATABASE_URL: postgresql://authme:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in env}@authme-db:5432/authme_prod
       PORT: "3001"
       NODE_ENV: production
       BASE_URL: https://auth.realstate-crm.homes
       TRUSTED_PROXIES: "*"
-      ADMIN_API_KEY: prod-authme-admin-key-d0i6e2f7h9i1j3k5l7m9n0o2p4q6r8s0
-      WEBHOOK_SECRET_KEY: prod-webhook-secret-9ff7ie6g616h3h6915gf346iid866i4655f0fggd
-      WEBHOOK_ENCRYPTION_SALT: prod-encryption-salt-d4e5f6g7h8i9d4e5f6g7h8i9d4e5f6g7
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?Set ADMIN_API_KEY in env}
+      WEBHOOK_SECRET_KEY: ${WEBHOOK_SECRET_KEY:?Set WEBHOOK_SECRET_KEY in env}
+      WEBHOOK_ENCRYPTION_SALT: ${WEBHOOK_ENCRYPTION_SALT:?Set WEBHOOK_ENCRYPTION_SALT in env}
     volumes:
       - ./authme-patches:/patches:ro
     entrypoint: ["/bin/sh", "/patches/entrypoint.sh"]
@@ -55,16 +55,16 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
-      DATABASE_URL: postgresql://crm_user:real-estate-prod-password-secure-change-me@host.docker.internal:5435/real_estate_crm_prod
+      DATABASE_URL: postgresql://crm_user:${DB_PASSWORD:?Set DB_PASSWORD in env}@host.docker.internal:5435/real_estate_crm_prod
       AUTHME_URL: http://crm-prod-authme:3001
       AUTHME_ISSUER_URL: https://auth.realstate-crm.homes
       AUTHME_REALM: real-estate
       AUTHME_CLIENT_ID: crm-backend
-      AUTHME_CLIENT_SECRET: change-me-after-setup
+      AUTHME_CLIENT_SECRET: ${AUTHME_CLIENT_SECRET:?Set AUTHME_CLIENT_SECRET in env}
       ADMIN_PORTAL_URL: https://admin.realstate-crm.homes
       AGENT_PORTAL_URL: https://agent.realstate-crm.homes
       UPLOAD_DIR: /app/uploads
-      JWT_SECRET: prod-jwt-secret-generate-with-openssl-rand
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in env}
       REDIS_URL: redis://crm-prod-redis:6379
       CORS_ORIGINS: https://admin.realstate-crm.homes,https://agent.realstate-crm.homes
       THROTTLE_TTL: "60000"

--- a/docker-compose.qa-server.yml
+++ b/docker-compose.qa-server.yml
@@ -12,7 +12,7 @@ services:
     container_name: crm-qa-authme-db
     environment:
       POSTGRES_USER: authme
-      POSTGRES_PASSWORD: authme-qa
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in env}
       POSTGRES_DB: authme_qa
     volumes:
       - authme-pgdata-qa:/var/lib/postgresql/data
@@ -24,20 +24,20 @@ services:
     networks:
       - crm-qa-network
 
-  # ── AuthMe IAM (QA) ────────────────────────────────────────────────────
+  # ── AuthMe IAM (QA) ───────────────────────────────────────────────────
   authme:
     image: islamawad/authme
     restart: unless-stopped
     container_name: crm-qa-authme
     environment:
-      DATABASE_URL: postgresql://authme:authme-qa@authme-db:5432/authme_qa
+      DATABASE_URL: postgresql://authme:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in env}@authme-db:5432/authme_qa
       PORT: "3001"
       NODE_ENV: production
       BASE_URL: https://qa-auth.realstate-crm.homes
       TRUSTED_PROXIES: "*"
-      ADMIN_API_KEY: qa-authme-admin-key-b8g4c0d5f7g9h1i3j5k7l9m0n2o4p6q8
-      WEBHOOK_SECRET_KEY: qa-webhook-secret-7dd5gc4e494f1f4793ed124ggb644g2433d8deeb
-      WEBHOOK_ENCRYPTION_SALT: qa-encryption-salt-b2c3d4e5f6g7b2c3d4e5f6g7b2c3d4e5
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?Set ADMIN_API_KEY in env}
+      WEBHOOK_SECRET_KEY: ${WEBHOOK_SECRET_KEY:?Set WEBHOOK_SECRET_KEY in env}
+      WEBHOOK_ENCRYPTION_SALT: ${WEBHOOK_ENCRYPTION_SALT:?Set WEBHOOK_ENCRYPTION_SALT in env}
     volumes:
       - ./authme-patches:/patches:ro
     entrypoint: ["/bin/sh", "/patches/entrypoint.sh"]
@@ -55,16 +55,16 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
-      DATABASE_URL: postgresql://crm_user:real-estate-qa-password-123@host.docker.internal:5433/real_estate_crm_qa
+      DATABASE_URL: postgresql://crm_user:${DB_PASSWORD:?Set DB_PASSWORD in env}@host.docker.internal:5433/real_estate_crm_qa
       AUTHME_URL: http://crm-qa-authme:3001
       AUTHME_ISSUER_URL: https://qa-auth.realstate-crm.homes
       AUTHME_REALM: real-estate-qa
       AUTHME_CLIENT_ID: crm-backend
-      AUTHME_CLIENT_SECRET: 69cffe662106e23d093d1c71fef4ec794c234b78cadb2a1487b7caffc0b12088
+      AUTHME_CLIENT_SECRET: ${AUTHME_CLIENT_SECRET:?Set AUTHME_CLIENT_SECRET in env}
       ADMIN_PORTAL_URL: https://qa-admin.realstate-crm.homes
       AGENT_PORTAL_URL: https://qa-agent.realstate-crm.homes
       UPLOAD_DIR: /app/uploads
-      JWT_SECRET: qa-jwt-secret-unique-value
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in env}
       REDIS_URL: redis://crm-qa-redis:6379
       CORS_ORIGINS: https://qa-admin.realstate-crm.homes,https://qa-agent.realstate-crm.homes
     extra_hosts:

--- a/docker-compose.uat-server.yml
+++ b/docker-compose.uat-server.yml
@@ -12,7 +12,7 @@ services:
     container_name: crm-uat-authme-db
     environment:
       POSTGRES_USER: authme
-      POSTGRES_PASSWORD: authme-uat
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in env}
       POSTGRES_DB: authme_uat
     volumes:
       - authme-pgdata-uat:/var/lib/postgresql/data
@@ -30,14 +30,14 @@ services:
     restart: unless-stopped
     container_name: crm-uat-authme
     environment:
-      DATABASE_URL: postgresql://authme:authme-uat@authme-db:5432/authme_uat
+      DATABASE_URL: postgresql://authme:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in env}@authme-db:5432/authme_uat
       PORT: "3001"
       NODE_ENV: production
       BASE_URL: https://uat-auth.realstate-crm.homes
       TRUSTED_PROXIES: "*"
-      ADMIN_API_KEY: uat-authme-admin-key-c9h5d1e6g8h0i2j4k6l8m1n3o5p7q9r1
-      WEBHOOK_SECRET_KEY: uat-webhook-secret-8ee6hd5f505g2g5804fe235hhc755h3544e9effc
-      WEBHOOK_ENCRYPTION_SALT: uat-encryption-salt-c3d4e5f6g7h8c3d4e5f6g7h8c3d4e5f6
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?Set ADMIN_API_KEY in env}
+      WEBHOOK_SECRET_KEY: ${WEBHOOK_SECRET_KEY:?Set WEBHOOK_SECRET_KEY in env}
+      WEBHOOK_ENCRYPTION_SALT: ${WEBHOOK_ENCRYPTION_SALT:?Set WEBHOOK_ENCRYPTION_SALT in env}
     volumes:
       - ./authme-patches:/patches:ro
     entrypoint: ["/bin/sh", "/patches/entrypoint.sh"]
@@ -55,16 +55,16 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
-      DATABASE_URL: postgresql://crm_user:real-estate-uat-password-123@host.docker.internal:5434/real_estate_crm_uat
+      DATABASE_URL: postgresql://crm_user:${DB_PASSWORD:?Set DB_PASSWORD in env}@host.docker.internal:5434/real_estate_crm_uat
       AUTHME_URL: http://crm-uat-authme:3001
       AUTHME_ISSUER_URL: https://uat-auth.realstate-crm.homes
       AUTHME_REALM: real-estate-uat
       AUTHME_CLIENT_ID: crm-backend
-      AUTHME_CLIENT_SECRET: change-me-after-setup
+      AUTHME_CLIENT_SECRET: ${AUTHME_CLIENT_SECRET:?Set AUTHME_CLIENT_SECRET in env}
       ADMIN_PORTAL_URL: https://uat-admin.realstate-crm.homes
       AGENT_PORTAL_URL: https://uat-agent.realstate-crm.homes
       UPLOAD_DIR: /app/uploads
-      JWT_SECRET: uat-jwt-secret-unique-value
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in env}
       REDIS_URL: redis://crm-uat-redis:6379
       CORS_ORIGINS: https://uat-admin.realstate-crm.homes,https://uat-agent.realstate-crm.homes
     extra_hosts:


### PR DESCRIPTION
Closes #210

Replaced all hardcoded plain-text secrets with `${VAR:?Set VAR in env}` references in:
- `docker-compose.prod-server.yml`
- `docker-compose.qa-server.yml`  
- `docker-compose.uat-server.yml`

Created `.env.prod.example`, `.env.qa.example`, `.env.uat.example` templates documenting required variables (without real values).

## Manual ops required (not automated — must be done by operator)

**All secrets that were exposed in repo history must be rotated before going live:**
- Production: POSTGRES_PASSWORD, ADMIN_API_KEY, WEBHOOK_SECRET_KEY, AUTHME_CLIENT_SECRET, JWT_SECRET
- QA: same secrets + AUTHME_CLIENT_SECRET value `69cffe66...`
- UAT: same pattern

Rotate by generating new values (`openssl rand -base64 32`) and updating in each environment's `.env.{env}` file.

## Test plan
- [x] `git grep -E \"(PASSWORD|SECRET|KEY)\s*[:=]\s*[a-zA-Z0-9]\" docker-compose.*.yml` returns no plain-value matches
- [x] All compose files only reference `${VAR}` placeholders
- [x] `.env.{prod,qa,uat}` are gitignored (via existing `.env.*` rule)
- [ ] All exposed secrets rotated in respective environments (manual)