### PR TITLE
fix: add app container healthcheck to docker-compose.dev.yml (#219)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,6 +36,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health/live"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
 volumes:
   pgdata:


### PR DESCRIPTION
Closes #219

Added healthcheck to app service in docker-compose.dev.yml using
`/api/health/live` endpoint (wget available in Alpine):

```yaml
healthcheck:
  test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health/live"]
  interval: 30s
  timeout: 5s
  retries: 3
  start_period: 30s
```

Other compose files (dev-full, dev-server, qa-server, uat-server, prod-server) already have app healthchecks.

## Test plan
- [x] docker-compose.dev.yml has healthcheck for app service
- [ ] `docker compose ps` shows app as (healthy) after stack starts