### PR TITLE
fix: increase nginx proxy timeouts for PDF generation endpoints (#220)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -59,6 +59,23 @@ server {
         proxy_read_timeout 60s;
     }
 
+    # ── PDF generation endpoints (can take 60-300s) ───────────────────────
+    location ~ ^/api/(contracts|invoices|properties|reports)/.*\.pdf$ {
+        proxy_pass http://nestjs;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Extended timeouts for PDF generation (large reports/contracts)
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
     # ── Uploaded files → NestJS (served via the uploads controller) ──────────
     location /uploads/ {
         proxy_pass http://nestjs;


### PR DESCRIPTION
Closes #220

Added dedicated location block for PDF endpoints with extended timeouts:
- proxy_read_timeout: 300s (up from 60s)
- proxy_send_timeout: 300s (up from 60s)
- Pattern: `^/api/(contracts|invoices|properties|reports)/.*\.pdf$`

Non-PDF endpoints keep the default 60s timeouts.

## Test plan
- [x] PDF endpoints have 300s timeout
- [x] Non-PDF endpoints keep 60s default