### PR TITLE
security: add CSP report-only header to nginx (#217)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,10 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # Content-Security-Policy (report-only for initial rollout)
+    # Staged via Content-Security-Policy-Report-Only until confirmed working
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://auth.realstate-crm.homes https://qa-auth.realstate-crm.homes https://uat-auth.realstate-crm.homes; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none';" always;
+
     # Gzip compression
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
Closes #217

Added CSP in report-only mode to monitor violations before enforcing:
```
Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://auth.realstate-crm.homes https://qa-auth.realstate-crm.homes https://uat-auth.realstate-crm.homes; ...
```

Allows Authme SSO domains, inline scripts (needed for React SSR), and data URIs. Report-only mode prevents breakage during rollout.

## Test plan
- [x] CSP header present in responses (report-only)
- [ ] No app-breaking violations in production console