### PR TITLE
feat: add structured logging with correlation IDs (#221)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
@@ -20,6 +20,7 @@ import { HealthModule } from './health/health.module.js';
 import { ReportsModule } from './reports/reports.module.js';
 import { UsersModule } from './users/users.module.js';
 import { SettingsModule } from './settings/settings.module.js';
+import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware.js';
 
 @Module({
   imports: [
@@ -69,4 +70,8 @@ import { SettingsModule } from './settings/settings.module.js';
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+  }
+}

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -24,7 +24,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
-
+    const req = request as Request & { id?: string };
+    const reqId = req.id;
     const isProduction = process.env.NODE_ENV === 'production';
 
     let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
@@ -46,7 +47,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
         error = (resp['error'] as string) ?? exception.name;
       }
     } else if (exception instanceof Error) {
-      this.logger.error(`Unhandled exception: ${exception.message}`, exception.stack);
+      this.logger.error({ reqId, err: exception.message }, exception.stack);
       if (isProduction) {
         message = 'Internal server error';
         error = 'Internal Server Error';
@@ -55,7 +56,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
         error = exception.name;
       }
     } else {
-      this.logger.error('Unknown exception', String(exception));
+      this.logger.error({ reqId }, 'Unknown exception');
     }
 
     if (isProduction) {

--- a/src/common/middleware/correlation-id.middleware.ts
+++ b/src/common/middleware/correlation-id.middleware.ts
@@ -1,0 +1,24 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+declare global {
+  namespace Express {
+    interface Request {
+      id: string;
+    }
+  }
+}
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(CorrelationIdMiddleware.name);
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const id = req.headers['x-request-id'] as string ?? randomUUID();
+    req.id = id;
+    res.setHeader('X-Request-Id', id);
+    this.logger.log(`Request ${id} started: ${req.method} ${req.url}`);
+    next();
+  }
+}


### PR DESCRIPTION
Closes #221

Added CorrelationIdMiddleware that:
- Generates unique request ID (or uses X-Request-Id from caller)
- Adds req.id to Express Request interface
- Sets X-Request-Id response header
- Logs request start with reqId

Updated HttpExceptionFilter to log errors with {reqId, err} context.

## Test plan
- [x] CorrelationIdMiddleware registered globally
- [x] X-Request-Id header added to responses
- [x] Errors include reqId in structured log output
- [ ] `docker compose logs app | jq .` parses as valid JSON (requires docker)