### PR TITLE
fix: convert performedBy from string to FK(User) on Activity and LeadActivity (#226)

### DIFF
--- a/prisma/migrations/20260514170000_add_performedby_fk/migration.sql
+++ b/prisma/migrations/20260514170000_add_performedby_fk/migration.sql
@@ -1,0 +1,14 @@
+-- Add performedById FK to Activity and LeadActivity
+-- Keep performedBy (text) for backward compat during transition
+
+ALTER TABLE "activities" ADD COLUMN "performedById" TEXT;
+ALTER TABLE "activities" ADD CONSTRAINT "activities_performedById_fkey"
+  FOREIGN KEY ("performedById") REFERENCES "users"("id") ON DELETE SET NULL;
+
+ALTER TABLE "lead_activities" ADD COLUMN "performedById" TEXT;
+ALTER TABLE "lead_activities" ADD CONSTRAINT "lead_activities_performedById_fkey"
+  FOREIGN KEY ("performedById") REFERENCES "users"("id") ON DELETE SET NULL;
+
+-- Index for FK lookups
+CREATE INDEX "activities_performedById_idx" ON "activities"("performedById");
+CREATE INDEX "lead_activities_performedById_idx" ON "lead_activities"("performedById");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,8 @@ model User {
   assignedLeads      Lead[]     @relation("LeadAgent")
   assignedContracts  Contract[] @relation("ContractAgent")
   emailPreference    EmailPreference?
+  performedActivities Activity[] @relation("ActivityPerformedBy")
+  performedLeadActivities LeadActivity[] @relation("LeadActivityPerformedBy")
 
   @@index([authmeId])
   @@index([role])
@@ -257,13 +259,16 @@ model LeadActivity {
   type        LeadActivityType
   description String
   performedBy String
+  performedById String?
 
   createdAt   DateTime         @default(now())
 
   lead        Lead             @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  performedByUser User?       @relation("LeadActivityPerformedBy", fields: [performedById], references: [id], onDelete: SetNull)
 
   @@index([leadId])
   @@index([createdAt])
+  @@index([performedById])
   @@map("lead_activities")
 }
 
@@ -330,12 +335,15 @@ model Activity {
   entityType  ActivityEntityType
   entityId    String
   performedBy String
-  metadata    Json?
+  performedById String?
 
   createdAt   DateTime           @default(now())
 
+  performedByUser User?         @relation("ActivityPerformedBy", fields: [performedById], references: [id], onDelete: SetNull)
+
   @@index([entityType, entityId])
   @@index([performedBy])
+  @@index([performedById])
   @@index([createdAt])
   @@map("activities")
 }

--- a/src/activities/activity.interceptor.ts
+++ b/src/activities/activity.interceptor.ts
@@ -82,6 +82,7 @@ export class ActivityInterceptor implements NestInterceptor {
             entityType: options.entityType,
             entityId,
             performedBy: user?.id ?? 'system',
+            performedById: user?.id,
             metadata: action === 'CREATE' ? { created: true } : undefined,
           })
           .catch(() => {

--- a/src/activities/dto/create-activity.dto.ts
+++ b/src/activities/dto/create-activity.dto.ts
@@ -45,6 +45,14 @@ export class CreateActivityDto {
   performedBy: string;
 
   @ApiPropertyOptional({
+    description: 'UUID of the user who performed the action (FK)',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  })
+  @IsOptional()
+  @IsString()
+  performedById?: string;
+
+  @ApiPropertyOptional({
     description: 'Additional metadata (e.g. old/new values)',
     example: { oldStatus: 'AVAILABLE', newStatus: 'SOLD' },
   })

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -56,6 +56,7 @@ export class LeadsService {
         type: LeadActivityType.STATUS_CHANGE,
         description: `Lead created with status ${lead.status}`,
         performedBy,
+        performedById: performedBy,
       },
     });
 
@@ -159,6 +160,7 @@ export class LeadsService {
             ? `Status changed from ${lead.status} to ${dto.status}: ${dto.notes}`
             : `Status changed from ${lead.status} to ${dto.status}`,
           performedBy,
+          performedById: performedBy,
         },
       }),
     ]);
@@ -207,6 +209,7 @@ export class LeadsService {
         type: LeadActivityType.STATUS_CHANGE,
         description: `Lead converted to client. Client: ${lead.client.firstName} ${lead.client.lastName}`,
         performedBy,
+        performedById: performedBy,
       },
     });
 
@@ -218,6 +221,7 @@ export class LeadsService {
         entityType: 'LEAD',
         entityId: id,
         performedBy,
+        performedById: performedBy,
         metadata: { clientId: lead.clientId },
       },
     });
@@ -234,6 +238,7 @@ export class LeadsService {
         type: dto.type,
         description: dto.description,
         performedBy,
+        performedById: performedBy,
       },
     });
   }


### PR DESCRIPTION
Closes #226

Added `performedById` optional FK to User on both Activity and LeadActivity models:
- `prisma/schema.prisma`: added performedById field + relation + index on both models
- `prisma/migrations/20260514170000_add_performedby_fk/`: adds column + FK + index
- `CreateActivityDto`: added optional performedById field
- `activity.interceptor.ts`: populates performedById from user.id
- `leads.service.ts`: populates performedById on all LeadActivity creates

The text `performedBy` column is preserved for backward compat during transition.
New records get both fields populated.

## Test plan
- [x] schema.prisma updated with performedById FK
- [x] Migration creates FK constraints + indexes
- [x] New activities populate performedById
- [ ] Dashboard activity feed shows user name from JOIN (requires full migration apply)