### PR TITLE
feat(#224): add EMAIL_TEST_MODE flag to prevent real emails in dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,13 @@ SMTP_USER=
 SMTP_PASS=
 EMAIL_FROM=noreply@realestate-crm.com
 
+# Email test mode: off | log | mailhog
+# - off: real SMTP send (production default)
+# - log: write email body to logger, skip SMTP send (development default)
+# - mailhog: route to MailHog container at mailhog:1025 regardless of SMTP_HOST
+# Can be overridden with EMAIL_TEST_MODE env var
+EMAIL_TEST_MODE=
+
 # ─── Rate Limiting ─────────────────────────────────────────────────────
 # Request rate limiting configuration (in milliseconds)
 # TTL = time window, LIMIT = max requests within that window

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -167,6 +167,21 @@ services:
           cpus: "0.5"
           memory: 512M
 
+  # ── MailHog (SMTP catch-all for development) ──────────────────────────────
+  mailhog:
+    image: mailhog/mailhog:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:1025:1025"   # SMTP server for apps to send mail
+      - "127.0.0.1:8025:8025"   # Web UI (open http://localhost:8025)
+    networks:
+      - crm-dev-network
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+
 volumes:
   pgdata:
     driver: local

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -31,6 +31,7 @@ export class EmailService implements OnModuleInit {
   private transporter!: Transporter;
   private templates: Map<string, Handlebars.TemplateDelegate> = new Map();
   private baseTemplate!: Handlebars.TemplateDelegate;
+  private testMode: 'off' | 'log' | 'mailhog';
 
   constructor(
     private readonly config: ConfigService,
@@ -44,16 +45,43 @@ export class EmailService implements OnModuleInit {
   }
 
   private initTransporter() {
-    this.transporter = nodemailer.createTransport({
-      host: this.config.get<string>('SMTP_HOST', 'localhost'),
-      port: this.config.get<number>('SMTP_PORT', 587),
-      secure: this.config.get<number>('SMTP_PORT', 587) === 465,
-      auth: {
-        user: this.config.get<string>('SMTP_USER', ''),
-        pass: this.config.get<string>('SMTP_PASS', ''),
-      },
-    });
-    this.logger.log('SMTP transporter initialized');
+    const nodeEnv = this.config.get<string>('NODE_ENV', 'development');
+    this.testMode = this.resolveTestMode(nodeEnv);
+
+    const from = this.config.get<string>('EMAIL_FROM', 'noreply@realestate-crm.com');
+
+    if (this.testMode === 'mailhog') {
+      this.transporter = nodemailer.createTransport({
+        host: 'mailhog',
+        port: 1025,
+        secure: false,
+      });
+      this.logger.log('Email mode: mailhog (captures to MailHog UI at http://localhost:8025)');
+    } else if (this.testMode === 'log') {
+      this.transporter = nodemailer.createTransport({
+        host: 'mailhog',
+        port: 1025,
+        secure: false,
+      });
+      this.logger.log('Email mode: log (emails written to logger, no SMTP send)');
+    } else {
+      this.transporter = nodemailer.createTransport({
+        host: this.config.get<string>('SMTP_HOST', 'localhost'),
+        port: this.config.get<number>('SMTP_PORT', 587),
+        secure: this.config.get<number>('SMTP_PORT', 587) === 465,
+        auth: {
+          user: this.config.get<string>('SMTP_USER', ''),
+          pass: this.config.get<string>('SMTP_PASS', ''),
+        },
+      });
+      this.logger.log(`Email mode: live (SMTP: ${this.config.get('SMTP_HOST')}) — real emails will be sent`);
+    }
+  }
+
+  private resolveTestMode(nodeEnv: string): 'off' | 'log' | 'mailhog' {
+    const configured = this.config.get<'off' | 'log' | 'mailhog'>('EMAIL_TEST_MODE');
+    if (configured) return configured;
+    return nodeEnv === 'production' ? 'off' : 'log';
   }
 
   private loadTemplates() {
@@ -156,6 +184,19 @@ export class EmailService implements OnModuleInit {
       });
 
       const from = this.config.get<string>('EMAIL_FROM', 'noreply@realestate-crm.com');
+
+      if (this.testMode === 'log') {
+        this.logger.log(`[EMAIL TEST MODE — not sent] From: ${from} | To: ${to} | Subject: ${subject}`);
+        this.logger.debug(`[EMAIL TEST MODE] Body:\n${html}`);
+        await this.prisma.emailLog.update({
+          where: { id: emailLogId },
+          data: {
+            status: EmailStatus.SENT,
+            sentAt: new Date(),
+          },
+        });
+        return;
+      }
 
       await this.transporter.sendMail({
         from,


### PR DESCRIPTION
## Summary
- Add `EMAIL_TEST_MODE` config: `off` (real SMTP), `log` (write email body to logger), `mailhog` (route to MailHog)
- Default: `log` when `NODE_ENV=development`, `off` in production
- Add MailHog container to `docker-compose.dev-full.yml` on ports 1025 (SMTP) and 8025 (web UI at http://localhost:8025)
- Document in `.env.example`

## Test plan
- [ ] Dev environment: emails log to console, no real SMTP connection opened
- [ ] Set `EMAIL_TEST_MODE=mailhog` — emails captured in MailHog web UI
- [ ] Set `EMAIL_TEST_MODE=off` with real SMTP — emails actually sent
- [ ] Start dev stack with docker-compose — MailHog UI accessible at http://localhost:8025

🤖 Generated with [Claude Code](https://claude.com/claude-code)