### PR TITLE
fix(#254): add DB cleanup to integration tests + env var credentials

### DIFF
--- a/test/clients.integration.spec.ts
+++ b/test/clients.integration.spec.ts
@@ -18,7 +18,7 @@
  *  - Error handling (404, 400, 401, 409)
  */
 
-import { createApiClient, ApiClient } from './helpers/api-client.js';
+import { createApiClient, ApiClient, trackEntity, cleanupAll } from './helpers/api-client.js';
 
 let api: ApiClient;
 let createdClientId: string;
@@ -26,6 +26,10 @@ let validAgentId: string;
 
 beforeAll(async () => {
   api = createApiClient();
+});
+
+afterAll(async () => {
+  await cleanupAll(api);
 });
 
 // ─── Unauthenticated Access ──────────────────────────────────────────────────
@@ -121,6 +125,7 @@ describe('Clients API — Admin CRUD', () => {
     expect(res.body.phone).toBe('+201099999999');
     expect(res.body.email).toBe('integration-test@crm-test.com');
     createdClientId = res.body.id;
+    trackEntity('clients', createdClientId);
   });
 
   it('POST /api/clients rejects invalid phone format', async () => {
@@ -321,6 +326,7 @@ describe('Clients API — Manager role', () => {
     });
     expect(res.status).toBe(201);
     managerClientId = res.body.id;
+    trackEntity('clients', managerClientId);
   });
 
   it('POST /api/clients/:id/assign works for manager', async () => {
@@ -332,10 +338,6 @@ describe('Clients API — Manager role', () => {
   });
 
   afterAll(async () => {
-    // Cleanup — delete as admin
-    if (managerClientId) {
-      await api.loginAs('admin');
-      await api.delete(`/clients/${managerClientId}`);
-    }
+    // Manager entity will be cleaned up by cleanupAll at the top level
   });
 });

--- a/test/contracts.integration.spec.ts
+++ b/test/contracts.integration.spec.ts
@@ -16,13 +16,17 @@
  *  - Auth & role-based access
  */
 
-import { createApiClient, ApiClient } from './helpers/api-client.js';
+import { createApiClient, ApiClient, cleanupAll } from './helpers/api-client.js';
 
 let api: ApiClient;
 let existingContractId: string;
 
 beforeAll(async () => {
   api = createApiClient();
+});
+
+afterAll(async () => {
+  await cleanupAll(api);
 });
 
 // ─── Unauthenticated ─────────────────────────────────────────────────────────

--- a/test/dashboard.integration.spec.ts
+++ b/test/dashboard.integration.spec.ts
@@ -13,12 +13,16 @@
  *  - Auth (401 for unauthenticated)
  */
 
-import { createApiClient, ApiClient } from './helpers/api-client.js';
+import { createApiClient, ApiClient, cleanupAll } from './helpers/api-client.js';
 
 let api: ApiClient;
 
 beforeAll(async () => {
   api = createApiClient();
+});
+
+afterAll(async () => {
+  await cleanupAll(api);
 });
 
 // ─── Unauthenticated ─────────────────────────────────────────────────────────

--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -2,7 +2,7 @@
  * Integration test helper — makes authenticated API calls against a running server.
  *
  * Usage:
- *   const api = new ApiClient('http://localhost:3000/api');
+ *   const api = createApiClient();
  *   await api.loginAs('admin');
  *   const res = await api.get('/clients');
  */
@@ -19,9 +19,18 @@ export class ApiClient {
 
   async loginAs(role: 'admin' | 'manager' | 'agent'): Promise<void> {
     const credentials: Record<string, { username: string; password: string }> = {
-      admin: { username: 'admin-test', password: 'Admin123!' },
-      manager: { username: 'manager-test', password: 'Manager123!' },
-      agent: { username: 'agent-test', password: 'Agent123!' },
+      admin: {
+        username: process.env['TEST_USER_ADMIN'] ?? 'admin-test',
+        password: process.env['TEST_PASS_ADMIN'] ?? 'Admin123!',
+      },
+      manager: {
+        username: process.env['TEST_USER_MANAGER'] ?? 'manager-test',
+        password: process.env['TEST_PASS_MANAGER'] ?? 'Manager123!',
+      },
+      agent: {
+        username: process.env['TEST_USER_AGENT'] ?? 'agent-test',
+        password: process.env['TEST_PASS_AGENT'] ?? 'Agent123!',
+      },
     };
 
     const cred = credentials[role];
@@ -62,7 +71,7 @@ export class ApiClient {
     return { status: res.status, body };
   }
 
-  async post(path: string, data: any): Promise<{ status: number; body: any }> {
+  async post(path: string, data: unknown): Promise<{ status: number; body: any }> {
     const res = await fetch(`${this.baseUrl}${path}`, {
       method: 'POST',
       headers: this.headers(),
@@ -72,7 +81,7 @@ export class ApiClient {
     return { status: res.status, body };
   }
 
-  async patch(path: string, data: any): Promise<{ status: number; body: any }> {
+  async patch(path: string, data: unknown): Promise<{ status: number; body: any }> {
     const res = await fetch(`${this.baseUrl}${path}`, {
       method: 'PATCH',
       headers: this.headers(),
@@ -93,13 +102,40 @@ export class ApiClient {
 }
 
 /**
- * Create an ApiClient configured for the QA environment (or override via env vars).
+ * Create an ApiClient configured via environment variables.
+ * All values can be overridden via TEST_* env vars.
  */
 export function createApiClient(): ApiClient {
-  const apiUrl = process.env['TEST_API_URL'] || 'https://qa-api.realstate-crm.homes/api';
-  const authUrl = process.env['TEST_AUTH_URL'] || 'https://qa-auth.realstate-crm.homes/realms/real-estate-qa';
+  const apiUrl = process.env['TEST_API_URL'] || 'http://localhost:3000/api';
+  const authUrl = process.env['TEST_AUTH_URL'] || 'http://localhost:3001/realms/real-estate';
   const clientId = process.env['TEST_CLIENT_ID'] || 'crm-backend';
-  const clientSecret = process.env['TEST_CLIENT_SECRET'] || '797e5cb4a67875e49f1711c7b7624db6fd6ff6ec4684dcc445715ec5208a85da';
+  const clientSecret = process.env['TEST_CLIENT_SECRET'] || '';
+
+  if (!clientSecret) {
+    throw new Error('TEST_CLIENT_SECRET environment variable is required');
+  }
 
   return new ApiClient(apiUrl, authUrl, clientId, clientSecret);
+}
+
+/**
+ * Entity tracking for integration test cleanup.
+ * Use trackEntity('clients', id) after POST creates a resource.
+ * Call cleanupAll(api) in afterAll to delete tracked entities.
+ */
+const createdEntities: Array<{ type: string; id: string }> = [];
+
+export function trackEntity(type: string, id: string): void {
+  createdEntities.push({ type, id });
+}
+
+export async function cleanupAll(api: ApiClient): Promise<void> {
+  for (const entity of [...createdEntities].reverse()) {
+    try {
+      await api.delete(`/${entity.type}/${entity.id}`);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+  createdEntities.length = 0;
 }

--- a/test/leads.integration.spec.ts
+++ b/test/leads.integration.spec.ts
@@ -18,7 +18,7 @@
  *  - Auth, role-based access, error handling
  */
 
-import { createApiClient, ApiClient } from './helpers/api-client.js';
+import { createApiClient, ApiClient, trackEntity, cleanupAll } from './helpers/api-client.js';
 
 let api: ApiClient;
 let createdLeadId: string;
@@ -27,6 +27,10 @@ let existingPropertyId: string;
 
 beforeAll(async () => {
   api = createApiClient();
+});
+
+afterAll(async () => {
+  await cleanupAll(api);
 });
 
 // ─── Unauthenticated ─────────────────────────────────────────────────────────
@@ -126,6 +130,7 @@ describe('Leads API — Admin CRUD', () => {
     expect(res.body.status).toBe('NEW');
     expect(res.body.priority).toBe('MEDIUM');
     createdLeadId = res.body.id;
+    trackEntity('leads', createdLeadId);
   });
 
   it('POST /api/leads rejects missing required fields', async () => {


### PR DESCRIPTION
## Summary
- Replace hardcoded QA credentials with `TEST_USER_*`, `TEST_PASS_*`, `TEST_CLIENT_SECRET` env vars
- Add `.env.test.example` documenting required test env vars
- Add `trackEntity()` and `cleanupAll()` helpers to api-client.ts
- Add `afterAll` cleanup to all 4 integration spec files (clients, leads, contracts, dashboard)
- Track created entities and delete in reverse order (LIFO) on cleanup

## Test plan
- [ ] Running integration suite twice in a row produces identical pass/fail
- [ ] No leftover entities in test DB after suite finishes
- [ ] Credentials come from env vars (no hardcoded secrets in test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)