### PR TITLE
fix: wire logout button to clear QueryClient cache and localStorage (#233)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -51,7 +51,7 @@ export default function App() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <BrowserRouter>
-          <AuthProvider>
+          <AuthProvider queryClient={queryClient}>
             <ErrorBoundary>
               <Routes>
                 {/* Public */}

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useCallback } from 'react'
+import { QueryClient } from '@tanstack/react-query'
 import { AuthProvider as AuthmeProvider, useAuth as useAuthme, useUser } from 'authme-sdk/react'
 import { authme } from '../lib/authme'
 import type { User } from '../types'
@@ -11,15 +12,15 @@ interface AuthContextValue {
   isLoading: boolean
   login: () => Promise<void>
   logout: () => void
+  queryClient: QueryClient
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
-function AuthContextBridge({ children }: { children: React.ReactNode }) {
+function AuthContextBridge({ children, queryClient }: { children: React.ReactNode; queryClient: QueryClient }) {
   const { isAuthenticated, isLoading, login, logout, getToken } = useAuthme()
   const authmeUser = useUser()
 
-  // Map AuthMe user profile to our internal User type
   const user: User | null = authmeUser
     ? {
         id: authmeUser.sub ?? '',
@@ -31,6 +32,12 @@ function AuthContextBridge({ children }: { children: React.ReactNode }) {
 
   const token = getToken?.() ?? null
 
+  const handleLogout = useCallback(() => {
+    queryClient.clear()
+    localStorage.clear()
+    logout()
+  }, [queryClient, logout])
+
   return (
     <AuthContext.Provider
       value={{
@@ -39,7 +46,8 @@ function AuthContextBridge({ children }: { children: React.ReactNode }) {
         isAuthenticated,
         isLoading,
         login: () => login(),
-        logout,
+        logout: handleLogout,
+        queryClient,
       }}
     >
       {children}
@@ -47,10 +55,10 @@ function AuthContextBridge({ children }: { children: React.ReactNode }) {
   )
 }
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({ children, queryClient }: { children: React.ReactNode; queryClient: QueryClient }) {
   return (
     <AuthmeProvider client={authme}>
-      <AuthContextBridge>{children}</AuthContextBridge>
+      <AuthContextBridge queryClient={queryClient}>{children}</AuthContextBridge>
     </AuthmeProvider>
   )
 }


### PR DESCRIPTION
Closes #233

Wired the existing logout button in admin-ui TopBar to properly clear session state on sign out.

## Summary
- The logout button in the user dropdown already existed and called useAuth().logout(), but logout was not clearing the React Query cache or localStorage state
- AuthProvider now receives the shared QueryClient instance and passes it down to the AuthContext
- handleLogout() now calls queryClient.clear() and localStorage.clear() before calling the underlying authme logout

## Test plan
- [x] admin-ui builds successfully
- [x] Logout button visible in user dropdown in TopBar
- [x] After logout, React Query cache is cleared, preventing stale data on re-login