### PR TITLE
fix(admin-ui): single QueryClient in main.tsx (#239)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { lazy, Suspense, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ThemeProvider } from './context/ThemeContext'
@@ -33,29 +33,19 @@ const AgentsListPage = lazy(() => import('./pages/agents/AgentsListPage'))
 const AgentDetailPage = lazy(() => import('./pages/agents/AgentDetailPage'))
 const SettingsPage = lazy(() => import('./pages/settings/SettingsPage'))
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 2,
-      refetchOnWindowFocus: false,
-    },
-  },
-})
-
 const PageLoader = () => (
   <div className="flex items-center justify-center h-full">
     <LoadingSpinner message="Loading..." />
   </div>
 )
 
-export default function App() {
+export default function App({ queryClient }: { queryClient: QueryClient }) {
   const { i18n } = useTranslation()
   useEffect(() => {
     document.documentElement.dir = i18n.language === 'ar' ? 'rtl' : 'ltr'
   }, [i18n.language])
 
   return (
-    <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <BrowserRouter>
           <AuthProvider queryClient={queryClient}>
@@ -123,6 +113,5 @@ export default function App() {
           </AuthProvider>
         </BrowserRouter>
       </ThemeProvider>
-    </QueryClientProvider>
   )
 }

--- a/admin-ui/src/main.tsx
+++ b/admin-ui/src/main.tsx
@@ -6,10 +6,15 @@ import './i18n'
 import App from './App.tsx'
 import './index.css'
 
+// Single canonical QueryClient instance for the entire admin-ui.
+// Defaults: retry=2 for failed queries, refetchOnWindowFocus=false to avoid
+// noisy background refreshes, staleTime=5 min so data stays usable across
+// route navigations within the same session.
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 1,
+      retry: 2,
+      staleTime: 5 * 60 * 1000,
       refetchOnWindowFocus: false,
     },
   },
@@ -18,7 +23,7 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <App queryClient={queryClient} />
     </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Canonical `QueryClient` moved to `main.tsx` with documented defaults: `retry=2`, `staleTime=5min`, `refetchOnWindowFocus=false`
- `App.tsx` no longer creates its own `QueryClient`; receives it as a prop instead
- `AuthProvider` and all React Query hooks now share the same instance

## Test plan
- [ ] `npm run build` passes
- [ ] Login flow works (QueryClient shared from main.tsx)
- [ ] No duplicate QueryClient warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)