### PR TITLE
fix(agent-ui): single QueryClient in main.tsx (#240)

### DIFF
--- a/agent-ui/src/App.tsx
+++ b/agent-ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { lazy, Suspense, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ThemeProvider } from './context/ThemeContext'
@@ -19,78 +19,67 @@ const ClientsPage = lazy(() => import('./pages/ClientsPage'))
 const ContractsPage = lazy(() => import('./pages/ContractsPage'))
 const ActivitiesPage = lazy(() => import('./pages/ActivitiesPage'))
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 2,
-      refetchOnWindowFocus: false,
-    },
-  },
-})
-
 const PageLoader = () => (
   <div className="flex items-center justify-center h-full">
     <LoadingSpinner message="Loading..." />
   </div>
 )
 
-export default function App() {
+export default function App({ queryClient }: { queryClient: QueryClient }) {
   const { i18n } = useTranslation()
   useEffect(() => {
     document.documentElement.dir = i18n.language === 'ar' ? 'rtl' : 'ltr'
   }, [i18n.language])
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <BrowserRouter>
-          <AuthProvider queryClient={queryClient}>
-            <ErrorBoundary>
-              <Suspense fallback={<PageLoader />}>
-                <Routes>
-                  {/* Public */}
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route path="/callback" element={<CallbackPage />} />
+    <ThemeProvider>
+      <BrowserRouter>
+        <AuthProvider queryClient={queryClient}>
+          <ErrorBoundary>
+            <Suspense fallback={<PageLoader />}>
+              <Routes>
+                {/* Public */}
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/callback" element={<CallbackPage />} />
 
-                  {/* Protected — wrapped in Layout */}
-                  <Route
-                    path="/"
-                    element={
-                      <ProtectedRoute>
-                        <Layout />
-                      </ProtectedRoute>
-                    }
-                  >
-                    <Route index element={<DashboardPage />} />
-                    <Route path="properties" element={<PropertiesPage />} />
-                    <Route path="leads" element={<LeadsPage />} />
-                    <Route path="clients" element={<ClientsPage />} />
-                    <Route path="contracts" element={<ContractsPage />} />
-                    <Route path="activities" element={<ActivitiesPage />} />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                  </Route>
+                {/* Protected — wrapped in Layout */}
+                <Route
+                  path="/"
+                  element={
+                    <ProtectedRoute>
+                      <Layout />
+                    </ProtectedRoute>
+                  }
+                >
+                  <Route index element={<DashboardPage />} />
+                  <Route path="properties" element={<PropertiesPage />} />
+                  <Route path="leads" element={<LeadsPage />} />
+                  <Route path="clients" element={<ClientsPage />} />
+                  <Route path="contracts" element={<ContractsPage />} />
+                  <Route path="activities" element={<ActivitiesPage />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Route>
 
-                  {/* Catch-all for routes outside the layout */}
-                  <Route path="*" element={<Navigate to="/login" replace />} />
-                </Routes>
-              </Suspense>
-            </ErrorBoundary>
+                {/* Catch-all for routes outside the layout */}
+                <Route path="*" element={<Navigate to="/login" replace />} />
+              </Routes>
+            </Suspense>
+          </ErrorBoundary>
 
-            <Toaster
-              position="top-right"
-              toastOptions={{
-                duration: 4000,
-                style: {
-                  borderRadius: '10px',
-                  background: '#1f2937',
-                  color: '#f9fafb',
-                  fontSize: '14px',
-                },
-              }}
-            />
-          </AuthProvider>
-        </BrowserRouter>
-      </ThemeProvider>
-    </QueryClientProvider>
+          <Toaster
+            position="top-right"
+            toastOptions={{
+              duration: 4000,
+              style: {
+                borderRadius: '10px',
+                background: '#1f2937',
+                color: '#f9fafb',
+                fontSize: '14px',
+              },
+            }}
+          />
+        </AuthProvider>
+      </BrowserRouter>
+    </ThemeProvider>
   )
 }

--- a/agent-ui/src/main.tsx
+++ b/agent-ui/src/main.tsx
@@ -1,12 +1,29 @@
 import './env'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './i18n'
 import App from './App.tsx'
 import './index.css'
 
+// Single canonical QueryClient instance for the entire agent-ui.
+// Defaults: retry=2 for failed queries, staleTime=5 min so data stays
+// usable across route navigations, refetchOnWindowFocus=false to avoid
+// noisy background refreshes.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 2,
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    },
+  },
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App queryClient={queryClient} />
+    </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Canonical `QueryClient` moved to `main.tsx` with documented defaults: `retry=2`, `staleTime=5min`, `refetchOnWindowFocus=false`
- `App.tsx` no longer creates its own `QueryClient`; receives it as a prop instead
- `AuthProvider` and all React Query hooks now share the same instance

## Test plan
- [ ] `npm run build` passes
- [ ] Login flow works
- [ ] No duplicate QueryClient warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)