### PR TITLE
fix(auth): add 5s timeout to authme.refreshTokens() (#243)

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -47,7 +47,10 @@ apiClient.interceptors.response.use(
       original._retry = true
       isRefreshing = true
       try {
-        const refreshed = await authme.refreshTokens()
+        const refreshed = await Promise.race([
+          authme.refreshTokens(),
+          new Promise<false>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
+        ])
         if (refreshed) {
           const newToken = authme.getAccessToken()!
           pendingRequests.forEach((cb) => cb(newToken))
@@ -57,7 +60,7 @@ apiClient.interceptors.response.use(
           return apiClient(original)
         }
       } catch {
-        // refresh failed
+        // refresh failed or timed out
       }
       isRefreshing = false
       pendingRequests = []

--- a/agent-ui/src/api/client.ts
+++ b/agent-ui/src/api/client.ts
@@ -47,7 +47,10 @@ apiClient.interceptors.response.use(
       original._retry = true
       isRefreshing = true
       try {
-        const refreshed = await authme.refreshTokens()
+        const refreshed = await Promise.race([
+          authme.refreshTokens(),
+          new Promise<false>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
+        ])
         if (refreshed) {
           const newToken = authme.getAccessToken()!
           pendingRequests.forEach((cb) => cb(newToken))
@@ -57,7 +60,7 @@ apiClient.interceptors.response.use(
           return apiClient(original)
         }
       } catch {
-        // refresh failed
+        // refresh failed or timed out
       }
       isRefreshing = false
       pendingRequests = []


### PR DESCRIPTION
Closes #243

## Summary
- Wrapped `authme.refreshTokens()` in `Promise.race` with a 5-second timeout in both `admin-ui` and `agent-ui` API clients
- On timeout, the interceptor clears `isRefreshing` and `pendingRequests`, then redirects to `/login`
- This prevents hung refresh operations from freezing the UI indefinitely

## Test plan
- [ ] `npm run build` passes in both admin-ui and agent-ui
- [ ] Simulate auth service hang — verify clean redirect to login within 5s
- [ ] Normal refresh flow still works (token refresh succeeds, requests proceed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)