### PR TITLE
[M7-16] Extract design tokens (colors, badges) from hardcoded Tailwind classes

### DIFF
--- a/admin-ui/src/components/dashboard/ActivityFeed.tsx
+++ b/admin-ui/src/components/dashboard/ActivityFeed.tsx
@@ -2,20 +2,11 @@ import { Clock } from 'lucide-react'
 import { ChartCard } from './ChartCard'
 import { Skeleton } from '../ui'
 import type { ActivityItem } from '../../types/dashboard'
+import { ACTIVITY_TYPE_ICONS } from './tokens'
 
 interface Props {
   data?: ActivityItem[]
   isLoading: boolean
-}
-
-const TYPE_ICONS: Record<string, string> = {
-  PROPERTY_CREATED: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400',
-  LEAD_CREATED: 'bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
-  LEAD_WON: 'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400',
-  LEAD_LOST: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
-  CONTRACT_SIGNED: 'bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400',
-  INVOICE_PAID: 'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400',
-  CLIENT_CREATED: 'bg-sky-100 text-sky-600 dark:bg-sky-900/30 dark:text-sky-400',
 }
 
 function timeAgo(dateStr: string): string {
@@ -60,7 +51,7 @@ export function ActivityFeed({ data, isLoading }: Props) {
             >
               <div
                 className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
-                  TYPE_ICONS[activity.type] ?? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
+                  ACTIVITY_TYPE_ICONS[activity.type] ?? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
                 }`}
               >
                 <Clock size={14} />

--- a/admin-ui/src/components/dashboard/LeadsPipelineChart.tsx
+++ b/admin-ui/src/components/dashboard/LeadsPipelineChart.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
   ResponsiveContainer,
   PieChart,
@@ -11,34 +12,17 @@ import {
   YAxis,
   CartesianGrid,
 } from 'recharts'
-import { useState } from 'react'
 import { ChartCard } from './ChartCard'
 import { Skeleton } from '../ui'
 import type { LeadsResponse } from '../../types/dashboard'
+import { STATUS_COLORS, formatStatus, CHART_TOOLTIP_STYLE } from './tokens'
+
+type ChartMode = 'donut' | 'bar'
 
 interface Props {
   data?: LeadsResponse
   isLoading: boolean
 }
-
-const STATUS_COLORS: Record<string, string> = {
-  NEW: '#6366f1',
-  CONTACTED: '#3b82f6',
-  QUALIFIED: '#8b5cf6',
-  PROPOSAL: '#f97316',
-  NEGOTIATION: '#f59e0b',
-  WON: '#22c55e',
-  LOST: '#ef4444',
-}
-
-function formatStatus(s: string): string {
-  return s
-    .replace(/_/g, ' ')
-    .toLowerCase()
-    .replace(/\b\w/g, (c) => c.toUpperCase())
-}
-
-type ChartMode = 'donut' | 'bar'
 
 export function LeadsPipelineChart({ data, isLoading }: Props) {
   const [mode, setMode] = useState<ChartMode>('donut')
@@ -113,13 +97,7 @@ export function LeadsPipelineChart({ data, isLoading }: Props) {
                   ))}
                 </Pie>
                 <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'rgba(17, 24, 39, 0.9)',
-                    border: 'none',
-                    borderRadius: '8px',
-                    color: '#f9fafb',
-                    fontSize: '12px',
-                  }}
+                  contentStyle={CHART_TOOLTIP_STYLE}
                 />
                 <Legend
                   iconType="circle"
@@ -139,13 +117,7 @@ export function LeadsPipelineChart({ data, isLoading }: Props) {
                 />
                 <YAxis tick={{ fontSize: 11 }} className="text-gray-500 dark:text-gray-400" />
                 <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'rgba(17, 24, 39, 0.9)',
-                    border: 'none',
-                    borderRadius: '8px',
-                    color: '#f9fafb',
-                    fontSize: '12px',
-                  }}
+                  contentStyle={CHART_TOOLTIP_STYLE}
                 />
                 <Bar dataKey="count" radius={[4, 4, 0, 0]}>
                   {pipeline.map((entry) => (

--- a/admin-ui/src/components/dashboard/PropertiesCharts.tsx
+++ b/admin-ui/src/components/dashboard/PropertiesCharts.tsx
@@ -9,20 +9,11 @@ import {
 import { ChartCard } from './ChartCard'
 import { Skeleton } from '../ui'
 import type { PropertiesResponse } from '../../types/dashboard'
+import { CHART_COLORS, formatLabel, CHART_TOOLTIP_STYLE } from './tokens'
 
 interface Props {
   data?: PropertiesResponse
   isLoading: boolean
-}
-
-const STATUS_COLORS = ['#6366f1', '#22c55e', '#f59e0b', '#ef4444', '#3b82f6', '#8b5cf6']
-const TYPE_COLORS = ['#6366f1', '#3b82f6', '#22c55e', '#f59e0b', '#f97316', '#ef4444', '#8b5cf6']
-
-function formatLabel(s: string): string {
-  return s
-    .replace(/_/g, ' ')
-    .toLowerCase()
-    .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 export function PropertiesCharts({ data, isLoading }: Props) {
@@ -65,18 +56,10 @@ export function PropertiesCharts({ data, isLoading }: Props) {
                     dataKey="value"
                   >
                     {byStatus.map((_, idx) => (
-                      <Cell key={idx} fill={STATUS_COLORS[idx % STATUS_COLORS.length]} />
+                      <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
                     ))}
                   </Pie>
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: 'rgba(17, 24, 39, 0.9)',
-                      border: 'none',
-                      borderRadius: '8px',
-                      color: '#f9fafb',
-                      fontSize: '12px',
-                    }}
-                  />
+                  <Tooltip contentStyle={CHART_TOOLTIP_STYLE} />
                   <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: '11px' }} />
                 </PieChart>
               </ResponsiveContainer>
@@ -105,18 +88,10 @@ export function PropertiesCharts({ data, isLoading }: Props) {
                     dataKey="value"
                   >
                     {byType.map((_, idx) => (
-                      <Cell key={idx} fill={TYPE_COLORS[idx % TYPE_COLORS.length]} />
+                      <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
                     ))}
                   </Pie>
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: 'rgba(17, 24, 39, 0.9)',
-                      border: 'none',
-                      borderRadius: '8px',
-                      color: '#f9fafb',
-                      fontSize: '12px',
-                    }}
-                  />
+                  <Tooltip contentStyle={CHART_TOOLTIP_STYLE} />
                   <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: '11px' }} />
                 </PieChart>
               </ResponsiveContainer>

--- a/admin-ui/src/components/dashboard/tokens.ts
+++ b/admin-ui/src/components/dashboard/tokens.ts
@@ -1,0 +1,57 @@
+// Design tokens — shared across admin-ui dashboard components
+
+export const STATUS_COLORS: Record<string, string> = {
+  NEW: '#6366f1',
+  CONTACTED: '#3b82f6',
+  QUALIFIED: '#8b5cf6',
+  PROPOSAL: '#f97316',
+  NEGOTIATION: '#f59e0b',
+  WON: '#22c55e',
+  LOST: '#ef4444',
+}
+
+export const STATUS_LABELS: Record<string, string> = {
+  NEW: 'New',
+  CONTACTED: 'Contacted',
+  QUALIFIED: 'Qualified',
+  PROPOSAL: 'Proposal',
+  NEGOTIATION: 'Negotiation',
+  WON: 'Won',
+  LOST: 'Lost',
+}
+
+export function formatStatus(s: string): string {
+  return STATUS_LABELS[s] ?? s.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export function formatLabel(s: string): string {
+  return s.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export const CHART_TOOLTIP_STYLE = {
+  backgroundColor: 'rgba(17, 24, 39, 0.9)',
+  border: 'none',
+  borderRadius: '8px',
+  color: '#f9fafb',
+  fontSize: '12px',
+} as const
+
+export const PROPERTY_STATUS_COLORS: Record<string, string> = {
+  AVAILABLE: '#22c55e',
+  RESERVED: '#f59e0b',
+  SOLD: '#6366f1',
+  RENTED: '#8b5cf6',
+  OFF_MARKET: '#6b7280',
+}
+
+export const ACTIVITY_TYPE_ICONS: Record<string, string> = {
+  PROPERTY_CREATED: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400',
+  LEAD_CREATED: 'bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+  LEAD_WON: 'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400',
+  LEAD_LOST: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+  CONTRACT_SIGNED: 'bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400',
+  INVOICE_PAID: 'bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400',
+  CLIENT_CREATED: 'bg-sky-100 text-sky-600 dark:bg-sky-900/30 dark:text-sky-400',
+}
+
+export const CHART_COLORS = ['#6366f1', '#22c55e', '#f59e0b', '#ef4444', '#3b82f6', '#8b5cf6']


### PR DESCRIPTION
## Summary
- Create `admin-ui/src/components/dashboard/tokens.ts` with shared constants:
  - `STATUS_COLORS`, `STATUS_LABELS`, `PROPERTY_STATUS_COLORS`
  - `ACTIVITY_TYPE_ICONS` badge classes
  - `CHART_COLORS`, `CHART_TOOLTIP_STYLE`
  - `formatStatus()` and `formatLabel()` utilities
- Replace hardcoded colors and `TYPE_ICONS` in `LeadsPipelineChart`, `PropertiesCharts`, `ActivityFeed` with imports from tokens
- Remove duplicate inline color arrays and formatting functions

## Test plan
- [ ] Verify dashboard charts (Lead Pipeline, Properties) still render correctly
- [ ] Verify activity feed badges show correct colors
- [ ] Check that mode switcher (donut/bar) works in Lead Pipeline