### PR TITLE
[M7-17] Remove unused Zustand dependency from admin-ui and agent-ui

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -24,8 +24,7 @@
         "react-i18next": "^17.0.8",
         "react-router-dom": "^7.6.0",
         "recharts": "^3.8.1",
-        "zod": "^4.4.3",
-        "zustand": "^5.0.12"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -4795,35 +4794,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
-      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     }
   }

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -26,8 +26,7 @@
     "react-i18next": "^17.0.8",
     "react-router-dom": "^7.6.0",
     "recharts": "^3.8.1",
-    "zod": "^4.4.3",
-    "zustand": "^5.0.12"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/agent-ui/package-lock.json
+++ b/agent-ui/package-lock.json
@@ -24,8 +24,7 @@
         "react-i18next": "^17.0.8",
         "react-router-dom": "^7.6.0",
         "recharts": "^3.8.1",
-        "zod": "^4.4.3",
-        "zustand": "^5.0.12"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -4795,35 +4794,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
-      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     }
   }

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -26,8 +26,7 @@
     "react-i18next": "^17.0.8",
     "react-router-dom": "^7.6.0",
     "recharts": "^3.8.1",
-    "zod": "^4.4.3",
-    "zustand": "^5.0.12"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",


### PR DESCRIPTION
## Summary
- Remove unused  dependency from both  and 
- docs/frontend-analysis.md:10. **Remove `zustand` from both packages** — it's listed as a dependency but nothing uses it returns no imports in either app
- Build passes in both portals after removal

## Test plan
- [ ] Verify 
> real-estate-crm@0.0.1 build
> nest build

Found 5 error(s). passes in admin-ui
- [ ] Verify 
> real-estate-crm@0.0.1 build
> nest build

Found 5 error(s). passes in agent-ui