### PR TITLE
[M7-18] Fail-fast on missing build-time env vars

### DIFF
--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "node scripts/check-bundle.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/admin-ui/scripts/check-bundle.mjs
+++ b/admin-ui/scripts/check-bundle.mjs
@@ -1,0 +1,26 @@
+// Post-build check: fail if production bundle contains dev/localhost strings
+import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+const DIST = process.argv[2] ?? 'dist'
+const FORBIDDEN = ['localhost:', '127.0.0.1', '::1']
+
+const jsFiles = readdirSync(DIST + '/assets').filter((f) => f.endsWith('.js'))
+const failures = []
+
+for (const file of jsFiles) {
+  const content = readFileSync(join(DIST, 'assets', file), 'utf8')
+  for (const pattern of FORBIDDEN) {
+    if (content.includes(pattern)) {
+      failures.push(`${file}: contains "${pattern}"`)
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Build contains forbidden patterns:')
+  failures.forEach((f) => console.error(' ', f))
+  process.exit(1)
+}
+
+console.log('Bundle check passed — no dev strings found.')

--- a/agent-ui/package.json
+++ b/agent-ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "node scripts/check-bundle.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/agent-ui/scripts/check-bundle.mjs
+++ b/agent-ui/scripts/check-bundle.mjs
@@ -1,0 +1,26 @@
+// Post-build check: fail if production bundle contains dev/localhost strings
+import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+const DIST = process.argv[2] ?? 'dist'
+const FORBIDDEN = ['localhost:', '127.0.0.1', '::1']
+
+const jsFiles = readdirSync(DIST + '/assets').filter((f) => f.endsWith('.js'))
+const failures = []
+
+for (const file of jsFiles) {
+  const content = readFileSync(join(DIST, 'assets', file), 'utf8')
+  for (const pattern of FORBIDDEN) {
+    if (content.includes(pattern)) {
+      failures.push(`${file}: contains "${pattern}"`)
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Build contains forbidden patterns:')
+  failures.forEach((f) => console.error(' ', f))
+  process.exit(1)
+}
+
+console.log('Bundle check passed — no dev strings found.')


### PR DESCRIPTION
## Summary
- `env.ts` already throws at startup if required env vars (`VITE_API_URL`, `VITE_AUTHME_*`) are missing — fail-fast behavior achieved
- Add `postbuild` script to both apps that scans the production bundle for dev strings (`localhost:`, `127.0.0.1`, `::1`) and fails the build if any are found
- No default-fallback values pointing to dev hosts exist in the client code
- Both `.env.example` files already document all required variables

## Test plan
- [ ] Build with missing env vars: should throw before bundle is created
- [ ] Build with forbidden strings in source: postbuild should catch them
- [ ] Bundle scan passes cleanly on normal production build