### PR TITLE
test: add admin-ui npm test to CI pipeline (#248)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Type check & Build
         run: npm run build
 
+      - name: Test
+        run: npm test
+
   # ── Agent UI ───────────────────────────────────────────────────────────
   agent-ui:
     name: CI / Frontend Agent UI


### PR DESCRIPTION
Closes #248

Wires admin-ui Vitest tests into the CI pipeline. The admin-ui job in ci.yml now runs `npm test` after the build step, ensuring every PR validates the test suite.

## Test plan
- [x] `cd admin-ui && npm test` passes
- [x] `cd admin-ui && npm run build` passes
- [x] CI includes `npm test` step for admin-ui job
