### PR TITLE
test: add DataTable component tests for agent-ui critical paths (#251)

### DIFF
--- a/agent-ui/src/test/DataTable.test.tsx
+++ b/agent-ui/src/test/DataTable.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DataTable } from '../components/ui/DataTable'
+import type { Column } from '../types'
+
+const mockColumns: Column<{ id: string; name: string; status: string }>[] = [
+  { key: 'name', header: 'Name', sortable: true },
+  { key: 'status', header: 'Status', sortable: false },
+]
+
+const mockData = [
+  { id: '1', name: 'Alice', status: 'active' },
+  { id: '2', name: 'Bob', status: 'inactive' },
+]
+
+describe('DataTable', () => {
+  it('renders loading spinner when loading prop is true', () => {
+    render(<DataTable columns={mockColumns} data={[]} loading />)
+    expect(screen.getByText('Loading data...')).toBeInTheDocument()
+  })
+
+  it('renders empty state when no data and no loading', () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={[]}
+        emptyTitle="No records"
+        emptyDescription="Nothing to show"
+      />
+    )
+    expect(screen.getByText('No records')).toBeInTheDocument()
+  })
+
+  it('renders all data rows', () => {
+    render(<DataTable columns={mockColumns} data={mockData} />)
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+  })
+
+  it('displays status for each row', () => {
+    render(<DataTable columns={mockColumns} data={mockData} />)
+    expect(screen.getByText('active')).toBeInTheDocument()
+    expect(screen.getByText('inactive')).toBeInTheDocument()
+  })
+})

--- a/agent-ui/src/test/setup.ts
+++ b/agent-ui/src/test/setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+Object.defineProperty(import.meta, 'env', {
+  value: {
+    VITE_API_URL: 'http://localhost:3000/api',
+    VITE_AUTHME_URL: 'http://localhost:3000',
+    VITE_AUTHME_REALM: 'test',
+    VITE_AUTHME_CLIENT_ID: 'test-client',
+    VITE_AUTHME_REDIRECT_URI: 'http://localhost:5174/callback',
+  },
+  writable: true,
+});
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
Closes #251

Adds component tests for agent-ui DataTable covering: empty state, data rendering, status display, and loading spinner. Provides a foundation for future test coverage expansion in agent-ui.

## Test plan
- [x] `cd agent-ui && npm test` passes
- [x] `cd agent-ui && npm run build` passes
- [x] 4 DataTable tests added (loading, empty state, data rows, status display)