### PR TITLE
feat: add PostgreSQL tsvector generated column for Property search (#212)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,8 @@ model Property {
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @updatedAt
 
+  searchVector    Unsupported("tsvector")?
+
   images          PropertyImage[]
   leads           Lead[]
   contracts       Contract[]


### PR DESCRIPTION
Closes #212

Add `searchVector Unsupported("tsvector")?` generated column to the Property model in schema.prisma. The column is already created via migration `20260514120000_add_property_search_vector`, so this change merely synchronizes the Prisma schema with the live database schema.

## Test plan
- [x] `npx prisma format` passes
- [x] `npx prisma generate` succeeds
- [x] Existing tsvector migration is unchanged (already applied)
- [x] Full-text search service uses \`@@\` operator with \`websearch_to_tsquery\`