### PR TITLE
chore: Add pre-commit hooks (husky + lint-staged) (#258)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -233,6 +233,18 @@ src/<module>/
   - `test:` Test additions/changes
   - `chore:` Build/tooling changes
 
+### Pre-commit Hooks
+
+This project uses [husky](https://typicode.github.io/husky/) + [lint-staged](https://github.com/lint-staged/lint-staged) to enforce linting and formatting before every commit.
+
+On every `git commit`, staged `*.ts`/`*.tsx` files are automatically run through:
+- `eslint --fix` (skips `e2e/**/*.ts`)
+- `prettier --write`
+
+If eslint reports errors, the commit is blocked. Fix them with `npm run lint -- --fix` before recommitting.
+
+The `prepare` script in `package.json` (`husky install`) runs automatically during `npm install`, so no extra setup is needed after cloning.
+
 ### Security
 
 - Helmet middleware for HTTP security headers


### PR DESCRIPTION
Closes #258

Add husky + lint-staged pre-commit hooks to enforce ESLint + Prettier on every commit. Hooks are already installed (from a prior PR) — this change adds documentation to development.md explaining how they work and that the `prepare` script in package.json handles automatic setup during `npm install`.

## Test plan
- [x] Pre-commit hook blocks commit when eslint reports errors
- [x] `npm install` runs `husky install` via the `prepare` script
- [x] Updated development.md documents the pre-commit workflow