### PR TITLE
docs: Add GitHub issue templates and PR template (#261)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "fix: [short description]"
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Context
+        Describe what was expected vs. what actually happened.
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How to reproduce the bug (be specific)
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, browser, etc.
+      value: |
+        - OS:
+        - Node version:
+        - Package manager:
+        - Backend/Frontend/Mobile:
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Subtasks
+        - [ ] Investigate root cause
+        - [ ] Implement fix
+        - [ ] Add tests
+        - [ ] Verify fix
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Acceptance criteria
+        - [ ] Bug is fixed and does not regress

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "feat: [short description]"
+labels: ["type:feat"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Context
+        Describe the problem or opportunity this feature addresses.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: What should happen?
+      placeholder: |
+        As a [role], I want [goal] so that [benefit].
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Subtasks
+        - [ ] Design solution
+        - [ ] Implement feature
+        - [ ] Add tests
+        - [ ] Update docs
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Acceptance criteria
+        - [ ] Feature works as described
+        - [ ] Tests pass
+        - [ ] Docs updated if needed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- One-paragraph description of what this PR does and why -->
+
+## Test plan
+
+- [ ] Tests pass (backend `npm test`, frontend `npm run build`, mobile `flutter analyze`)
+- [ ] Feature works as described in the issue
+- [ ] No regressions in related functionality
+
+<!-- For backend changes: run `npm run lint && npm test` -->
+<!-- For frontend changes: run `npm run build` in the affected app -->
+<!-- For mobile changes: run `flutter analyze` -->


### PR DESCRIPTION
Closes #261

Added GitHub issue templates and PR template:
-  — structured format with Context, Steps, Expected/Actual, Environment, Subtasks, Acceptance criteria
-  — structured format with Context, Description, Subtasks, Acceptance criteria
-  — disables blank issues
-  — requires summary and test plan checklist

## Test plan
- [x] Issue templates have correct YAML structure
- [x] PR template has summary and test plan fields

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>