### PR TITLE
fix: RFC 4180 CSV export with proper comma/quote escaping (#264)

### DIFF
--- a/admin-ui/src/pages/clients/ClientsListPage.tsx
+++ b/admin-ui/src/pages/clients/ClientsListPage.tsx
@@ -4,7 +4,7 @@ import { Users, Plus, Mail, Phone, AlertTriangle, Download, Filter, X } from 'lu
 import { Button, DataTable, SearchBar, Select, StatsCard } from '../../components/ui'
 import { useClientsList, useClientStats, useDeleteClient } from '../../hooks/useClients'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
-import { formatDate } from '../../utils'
+import { formatDate, toCsv } from '../../utils'
 import toast from 'react-hot-toast'
 import type { ClientType, ClientSource, ClientFilter } from '../../types/client'
 import type { Column } from '../../types'
@@ -73,21 +73,18 @@ export default function ClientsListPage() {
       toast.error('No clients to export')
       return
     }
-    const headers = ['Name', 'Email', 'Phone', 'Type', 'Source', 'Created']
-    const csvRows = [
-      headers.join(','),
-      ...rows.map((r) =>
-        [
-          `"${String(r.firstName)} ${String(r.lastName)}"`,
-          `"${String(r.email ?? '')}"`,
-          `"${String(r.phone)}"`,
-          String(r.type),
-          String(r.source ?? ''),
-          formatDate(String(r.createdAt)),
-        ].join(',')
-      ),
-    ]
-    const blob = new Blob([csvRows.join('\n')], { type: 'text/csv' })
+    const csv = toCsv(
+      rows.map((r) => ({
+        Name: `${r.firstName} ${r.lastName}`,
+        Email: r.email ?? '',
+        Phone: r.phone,
+        Type: r.type,
+        Source: r.source ?? '',
+        Created: formatDate(String(r.createdAt)),
+      })),
+      ['Name', 'Email', 'Phone', 'Type', 'Source', 'Created'],
+    )
+    const blob = new Blob([csv], { type: 'text/csv' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url

--- a/admin-ui/src/utils/csv.spec.ts
+++ b/admin-ui/src/utils/csv.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { toCsv, escapeCsvField } from './csv';
+
+describe('escapeCsvField', () => {
+  it('returns plain string for simple values', () => {
+    expect(escapeCsvField('hello')).toBe('hello');
+  });
+
+  it('wraps field with comma in quotes', () => {
+    expect(escapeCsvField('hello, world')).toBe('"hello, world"');
+  });
+
+  it('wraps field with double quote in quotes and doubles inner quotes', () => {
+    expect(escapeCsvField('say "hello"')).toBe('"say ""hello"""');
+  });
+
+  it('wraps field with newline in quotes', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+  });
+
+  it('handles null and undefined', () => {
+    expect(escapeCsvField(null)).toBe('');
+    expect(escapeCsvField(undefined)).toBe('');
+  });
+
+  it('converts numbers and booleans to strings', () => {
+    expect(escapeCsvField(42)).toBe('42');
+    expect(escapeCsvField(true)).toBe('true');
+  });
+});
+
+describe('toCsv', () => {
+  it('returns empty string for empty rows', () => {
+    expect(toCsv([])).toBe('');
+  });
+
+  it('uses object keys as headers by default', () => {
+    expect(toCsv([{ name: 'Alice', age: 30 }])).toBe('name,age\nAlice,30');
+  });
+
+  it('respects custom header order', () => {
+    const rows = [{ name: 'Alice', age: 30 }];
+    expect(toCsv(rows, ['age', 'name'])).toBe('age,name\n30,Alice');
+  });
+
+  it('escapes fields containing commas', () => {
+    const rows = [{ name: 'Doe, John' }];
+    expect(toCsv(rows)).toBe('name\n"Doe, John"');
+  });
+
+  it('escapes fields containing double quotes', () => {
+    const rows = [{ name: 'Bob "TheBuilder"' }];
+    expect(toCsv(rows)).toBe('name\n"Bob ""TheBuilder"""');
+  });
+
+  it('escapes fields containing newlines', () => {
+    const rows = [{ name: 'Line1\nLine2' }];
+    expect(toCsv(rows)).toBe('name\n"Line1\nLine2"');
+  });
+
+  it('handles mixed adversarial inputs', () => {
+    const rows = [{ name: 'Smith, "Bob"' }];
+    expect(toCsv(rows)).toBe('name\n"Smith, ""Bob"""');
+  });
+});

--- a/admin-ui/src/utils/csv.ts
+++ b/admin-ui/src/utils/csv.ts
@@ -1,0 +1,35 @@
+/**
+ * RFC 4180-compliant CSV encoder.
+ * Handles commas, quotes, and newlines in field values.
+ */
+
+export interface CsvRow {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+/**
+ * Escapes a single field value per RFC 4180:
+ * - Fields containing commas, quotes, or newlines are wrapped in double quotes
+ * - Double quotes inside a field are doubled (" → "")
+ */
+export function escapeCsvField(value: string | number | boolean | null | undefined): string {
+  const str = String(value ?? '');
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Converts an array of objects to a CSV string.
+ * Uses the keys of the first row as headers.
+ */
+export function toCsv(rows: CsvRow[], headers?: string[]): string {
+  if (rows.length === 0) return '';
+  const keys = headers ?? Object.keys(rows[0]);
+  const lines = [
+    keys.join(','),
+    ...rows.map((row) => keys.map((k) => escapeCsvField(row[k])).join(',')),
+  ];
+  return lines.join('\n');
+}

--- a/admin-ui/src/utils/index.ts
+++ b/admin-ui/src/utils/index.ts
@@ -4,6 +4,8 @@ export function cn(...inputs: ClassValue[]) {
   return clsx(inputs);
 }
 
+export { toCsv, escapeCsvField } from './csv';
+
 export function formatCurrency(amount: number, currency = 'SAR', locale?: string): string {
   return new Intl.NumberFormat(locale ?? 'en-US', { style: 'currency', currency }).format(amount);
 }


### PR DESCRIPTION
Closes #264

Added admin-ui/src/utils/csv.ts with RFC 4180-compliant escapeCsvField and toCsv utilities. Replaced the inline CSV builder in ClientsListPage that was concatenating strings without escaping commas or quotes.

## Test plan
- npx vitest run src/utils/csv.spec.ts — 13 tests passing
- Smith comma quote Bob row parses cleanly in Excel