### PR TITLE
fix: Accessibility improvements (#265)

### DIFF
--- a/admin-ui/src/components/ui/ConfirmDialog.tsx
+++ b/admin-ui/src/components/ui/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle } from 'lucide-react'
 import { Button } from './Button'
 import { cn } from '../../utils'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
 
 interface ConfirmDialogProps {
   isOpen: boolean
@@ -25,6 +26,8 @@ export function ConfirmDialog({
   onCancel,
   loading = false,
 }: ConfirmDialogProps) {
+  const ref = useFocusTrap(isOpen, onCancel);
+
   if (!isOpen) return null
 
   return (
@@ -32,6 +35,7 @@ export function ConfirmDialog({
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       role="dialog"
       aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
     >
       {/* Backdrop */}
       <div
@@ -40,6 +44,7 @@ export function ConfirmDialog({
       />
       {/* Panel */}
       <div
+        ref={ref as React.RefObject<HTMLDivElement>}
         className={cn(
           'relative w-full max-w-md rounded-xl bg-white shadow-xl p-6',
           'dark:bg-gray-800 dark:border dark:border-gray-700',
@@ -50,7 +55,7 @@ export function ConfirmDialog({
             <AlertTriangle size={20} className="text-red-600 dark:text-red-400" />
           </div>
           <div className="flex-1">
-            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
+            <h3 id="confirm-dialog-title" className="text-base font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
             <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{message}</p>
           </div>
         </div>

--- a/admin-ui/src/components/ui/DataTable.tsx
+++ b/admin-ui/src/components/ui/DataTable.tsx
@@ -82,7 +82,7 @@ export function DataTable<T extends Record<string, unknown>>({
   const secondaryCols = columns.slice(1)
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3" data-datatable>
       {showCards ? (
         /* ── Mobile card view ── */
         <div className="flex flex-col gap-3">
@@ -201,6 +201,14 @@ export function DataTable<T extends Record<string, unknown>>({
                   <tr
                     key={String(row[keyField] ?? i)}
                     onClick={() => onRowClick?.(row)}
+                    tabIndex={onRowClick ? 0 : undefined}
+                    data-datatable-row
+                    onKeyDown={(e) => {
+                      if ((e.key === 'Enter' || e.key === ' ') && onRowClick) {
+                        e.preventDefault();
+                        onRowClick(row);
+                      }
+                    }}
                     className={cn(
                       'transition-colors',
                       onRowClick && 'cursor-pointer hover:bg-indigo-50/60 dark:hover:bg-indigo-900/10',

--- a/admin-ui/src/components/ui/FormField.tsx
+++ b/admin-ui/src/components/ui/FormField.tsx
@@ -25,7 +25,11 @@ export function FormField<T extends FieldValues>({
         </label>
       )}
       {children}
-      {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>}
+      {error && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert" aria-live="polite">
+          {error}
+        </p>
+      )}
     </div>
   )
 }

--- a/admin-ui/src/hooks/useFocusTrap.ts
+++ b/admin-ui/src/hooks/useFocusTrap.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Focus trap hook — traps Tab navigation within the given container.
+ * Focus moves to first focusable element on mount, and returns to trigger on unmount.
+ */
+export function useFocusTrap(isActive: boolean, onEscape?: () => void) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+    previouslyFocused.current = document.activeElement;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusable = container.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && onEscape) {
+        onEscape();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      if (focusable.length === 0) return;
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    };
+
+    container.addEventListener('keydown', handleKeyDown);
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown);
+      if (previouslyFocused.current instanceof HTMLElement) {
+        previouslyFocused.current.focus();
+      }
+    };
+  }, [isActive, onEscape]);
+
+  return containerRef;
+}


### PR DESCRIPTION
Closes #265

Added focus trap, keyboard nav, and form error accessibility improvements.

## Summary
- Added  hook for modal focus trapping
- ConfirmDialog auto-focuses on open and returns focus on close
- DataTable rows: tabIndex + Enter/Space keyboard activation
- FormField error messages: role=alert aria-live=polite
- Toast: react-hot-toast v2 API does not expose container ARIA props — noted as known limitation

## Test plan
- admin-ui build passes
- ConfirmDialog focus trap: Tab cycles within, Esc closes, focus returns