### PR TITLE
chore: Remove TODO comment for unimplemented global search (#269)

### DIFF
--- a/admin-ui/src/components/layout/TopBar.tsx
+++ b/admin-ui/src/components/layout/TopBar.tsx
@@ -33,7 +33,8 @@ export function TopBar({ children }: { children?: React.ReactNode }) {
   }, [])
 
   function handleSearch(_query: string) {
-    // TODO: implement global search
+    // Global search is not implemented — users should use the specific
+    // search capabilities on each page (properties, leads, clients).
   }
 
   function switchLanguage(lang: string) {


### PR DESCRIPTION
Closes #269

Removed the `// TODO: implement global search` comment from TopBar.tsx and replaced it with a clarifying note that global search is not planned — individual pages have their own search capabilities.

The SearchBar component is kept in the UI as a no-op. No backend search endpoint was added.

## Acceptance criteria
- [x] No `// TODO` for global search left in TopBar.tsx
- [x] Clarifying comment explains the decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)