### PR TITLE
fix(docker): rebuild images for npm workspaces + fix prod entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,46 @@
-# Stage 1: Dependencies
+# ==============================================================================
+# Real Estate CRM — Multi-stage Dockerfile (npm workspaces monorepo)
+# ==============================================================================
+
+# Stage 1: Install all workspaces. The root package-lock.json governs
+# everything; admin-ui / agent-ui / packages/* are npm workspaces and the
+# @crm/* packages are linked locally during `npm ci`.
 FROM node:22-alpine AS deps
 WORKDIR /app
+# Every workspace manifest must be present before `npm ci`
 COPY package.json package-lock.json ./
+COPY packages/shared-api/package.json ./packages/shared-api/
+COPY packages/shared-components/package.json ./packages/shared-components/
+COPY packages/shared-types/package.json ./packages/shared-types/
+COPY admin-ui/package.json ./admin-ui/
+COPY agent-ui/package.json ./agent-ui/
+# Root postinstall runs `prisma generate`, so the schema must exist first
+COPY prisma ./prisma
+COPY prisma.config.ts ./
 RUN npm ci
 
-# Stage 1b: Admin UI dependencies
-FROM node:22-alpine AS admin-deps
-WORKDIR /app/admin-ui
-COPY admin-ui/package.json admin-ui/package-lock.json ./
-RUN npm ci
-
-# Stage 1c: Agent UI dependencies
-FROM node:22-alpine AS agent-deps
-WORKDIR /app/agent-ui
-COPY agent-ui/package.json agent-ui/package-lock.json ./
-RUN npm ci
-
-# Stage 2: Build
+# Stage 2: Build backend + both UIs
 FROM node:22-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=admin-deps /app/admin-ui/node_modules ./admin-ui/node_modules
-COPY --from=agent-deps /app/agent-ui/node_modules ./agent-ui/node_modules
 COPY . .
-# Build UIs (Vite picks up .env.production files automatically)
-RUN cd admin-ui && npm run build
-RUN cd agent-ui && npm run build
-# Generate Prisma client and build NestJS
-RUN npx prisma generate
+RUN npm run build --workspace admin-ui
+RUN npm run build --workspace agent-ui
 RUN npm run build
-# Copy UI build output into dist
-RUN cp -r admin-ui/dist dist/admin-ui
-RUN cp -r agent-ui/dist dist/agent-ui
-# Ensure email templates are alongside compiled email service
-RUN cp -r src/email/templates dist/src/email/templates 2>/dev/null || true
+# Co-locate UI bundles + email templates with the compiled backend
+RUN cp -r admin-ui/dist dist/admin-ui \
+ && cp -r agent-ui/dist dist/agent-ui \
+ && cp -r src/email/templates dist/src/email/templates 2>/dev/null || true
 
-# Stage 3: Production
+# Stage 3: Production runtime
 FROM node:22-alpine AS production
 WORKDIR /app
-
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/prisma ./prisma
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/package-lock.json ./package-lock.json
-
-# Remove dev dependencies
-RUN npm prune --omit=dev
+RUN npm prune --omit=dev --ignore-scripts
 
 ENV NODE_ENV=production
 EXPOSE 3000

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,54 +1,34 @@
 # ==============================================================================
-# Real Estate CRM — Production Multi-Stage Dockerfile
+# Real Estate CRM — Production Multi-Stage Dockerfile (npm workspaces monorepo)
 # ==============================================================================
 
-# ── Stage 1a: Backend dependencies ───────────────────────────────────────────
-FROM node:22-alpine AS backend-deps
+# ── Stage 1: Install all workspaces ──────────────────────────────────────────
+# Root package-lock.json governs the whole monorepo; @crm/* shared packages
+# are linked locally during `npm ci`.
+FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
-# Prisma needs the schema to generate the client
+COPY packages/shared-api/package.json ./packages/shared-api/
+COPY packages/shared-components/package.json ./packages/shared-components/
+COPY packages/shared-types/package.json ./packages/shared-types/
+COPY admin-ui/package.json ./admin-ui/
+COPY agent-ui/package.json ./agent-ui/
+# Root postinstall runs `prisma generate` — schema must be present first
 COPY prisma ./prisma
 COPY prisma.config.ts ./
-RUN npx prisma generate
-
-# ── Stage 1b: Admin UI dependencies ─────────────────────────────────────────
-FROM node:22-alpine AS admin-deps
-WORKDIR /app
-COPY admin-ui/package.json admin-ui/package-lock.json ./
 RUN npm ci
 
-# ── Stage 1c: Agent UI dependencies ─────────────────────────────────────────
-FROM node:22-alpine AS agent-deps
+# ── Stage 2: Build backend + both UIs ────────────────────────────────────────
+FROM node:22-alpine AS build
 WORKDIR /app
-COPY agent-ui/package.json agent-ui/package-lock.json ./
-RUN npm ci
-
-# ── Stage 2a: Build Admin UI ────────────────────────────────────────────────
-FROM node:22-alpine AS admin-build
-WORKDIR /app
-COPY --from=admin-deps /app/node_modules ./node_modules
-COPY admin-ui/ ./
-ENV VITE_API_BASE_URL=/api
-RUN npm run build
-
-# ── Stage 2b: Build Agent UI ────────────────────────────────────────────────
-FROM node:22-alpine AS agent-build
-WORKDIR /app
-COPY --from=agent-deps /app/node_modules ./node_modules
-COPY agent-ui/ ./
-ENV VITE_API_BASE_URL=/api
-RUN npm run build
-
-# ── Stage 2c: Build NestJS Backend ──────────────────────────────────────────
-FROM node:22-alpine AS backend-build
-WORKDIR /app
-COPY --from=backend-deps /app/node_modules ./node_modules
-COPY --from=backend-deps /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ENV VITE_API_BASE_URL=/api
+RUN npm run build --workspace admin-ui
+RUN npm run build --workspace agent-ui
 RUN npm run build
 
-# ── Stage 3: Production image ───────────────────────────────────────────────
+# ── Stage 3: Production image ────────────────────────────────────────────────
 FROM node:22-alpine AS production
 LABEL maintainer="Real Estate CRM Team"
 LABEL description="Real Estate CRM production image"
@@ -57,28 +37,22 @@ RUN apk add --no-cache dumb-init curl
 
 WORKDIR /app
 
-# Copy backend build
-COPY --from=backend-build /app/dist ./dist
-COPY --from=backend-build /app/prisma ./prisma
-COPY --from=backend-build /app/prisma.config.ts ./prisma.config.ts
-COPY --from=backend-build /app/package.json ./package.json
-COPY --from=backend-build /app/package-lock.json ./package-lock.json
+# Backend build output + runtime files
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+COPY --from=build /app/node_modules ./node_modules
 
-# Copy production node_modules (with Prisma client)
-COPY --from=backend-deps /app/node_modules ./node_modules
+# UI bundles for nginx to serve (and as backend fallback)
+COPY --from=build /app/admin-ui/dist ./public/admin
+COPY --from=build /app/agent-ui/dist ./public/agent
 
-# Copy UI builds into /app/public for nginx to serve (also available as fallback)
-COPY --from=admin-build /app/dist ./public/admin
-COPY --from=agent-build /app/dist ./public/agent
+# Drop dev dependencies (ignore-scripts so prune doesn't re-run postinstall)
+RUN npm prune --omit=dev --ignore-scripts 2>/dev/null || true
 
-# Prune dev dependencies
-RUN npm prune --omit=dev 2>/dev/null || true
-
-# Create uploads directory
-RUN mkdir -p /app/uploads
-
-# Set ownership
-RUN chown -R node:node /app
+RUN mkdir -p /app/uploads && chown -R node:node /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -90,4 +64,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "dist/main"]
+CMD ["node", "dist/src/main"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "admin:dev": "cd admin-ui && npm run dev",
     "agent:dev": "cd agent-ui && npm run dev",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
## Summary

Follow-up #2 from the post-autobuild stabilization. The #266 monorepo conversion broke both Dockerfiles (per-UI `npm ci` against now-deleted nested lockfiles; `cd <ui> && npm run build` can't resolve `@crm/*`).

- **Dockerfile** & **Dockerfile.prod**: single root `npm ci` install stage with all workspace manifests + prisma schema; build UIs via `--workspace`
- **Fixed latent runtime bug**: `Dockerfile.prod` CMD was `node dist/main` but `nest build` emits `dist/src/main` → container would crash on start. Also fixed `package.json` `start:prod`.

## Verified locally

- ✅ `docker build -f Dockerfile .` succeeds end-to-end (all stages)
- ✅ Container boots NestJS past module load (Prisma/Passport/Multer init)

## Test plan

- [x] Docker image builds
- [x] Entrypoint path correct (`dist/src/main.js` present, app bootstraps)
- [ ] CI `Docker Build` check goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)