### PR TITLE
test: repair stale-mock suites (batch 1) — health, contracts, email

### DIFF
--- a/src/contracts/contracts.controller.spec.ts
+++ b/src/contracts/contracts.controller.spec.ts
@@ -3,6 +3,7 @@ import { ContractsController } from './contracts.controller.js';
 import { ContractsService } from './contracts.service.js';
 import { ContractType, ContractStatus, UserRole } from '@prisma/client';
 import { AuthenticatedUser } from '../common/decorators/current-user.decorator.js';
+import { IdempotencyInterceptor } from '../common/interceptors/idempotency.interceptor.js';
 
 const mockService = {
   create: jest.fn(),
@@ -35,7 +36,10 @@ describe('ContractsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ContractsController],
       providers: [{ provide: ContractsService, useValue: mockService }],
-    }).compile();
+    })
+      .overrideInterceptor(IdempotencyInterceptor)
+      .useValue({ intercept: (_ctx: unknown, next: { handle: () => unknown }) => next.handle() })
+      .compile();
 
     controller = module.get<ContractsController>(ContractsController);
     jest.clearAllMocks();

--- a/src/email/email.service.spec.ts
+++ b/src/email/email.service.spec.ts
@@ -16,6 +16,11 @@ describe('EmailService', () => {
       update: jest.fn(),
       findUnique: jest.fn(),
     },
+    emailPreference: {
+      findUnique: jest.fn().mockResolvedValue({ userId: 'u1', unsubscribeToken: 'tok' }),
+      create: jest.fn().mockResolvedValue({ userId: 'u1', unsubscribeToken: 'tok' }),
+      update: jest.fn().mockResolvedValue({ userId: 'u1', unsubscribeToken: 'tok' }),
+    },
   };
 
   const mockQueue = {

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -4,10 +4,10 @@ import { PrismaService } from '../prisma/prisma.service.js';
 
 describe('HealthController', () => {
   let controller: HealthController;
-  let prisma: { $queryRawUnsafe: jest.Mock };
+  let prisma: { $queryRaw: jest.Mock };
 
   beforeEach(async () => {
-    prisma = { $queryRawUnsafe: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    prisma = { $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
@@ -27,7 +27,7 @@ describe('HealthController', () => {
     });
 
     it('should return degraded when database is down', async () => {
-      prisma.$queryRawUnsafe.mockRejectedValueOnce(new Error('Connection refused'));
+      prisma.$queryRaw.mockRejectedValueOnce(new Error('Connection refused'));
       const result = await controller.check();
       expect(result.status).toBe('degraded');
       expect(result.database).toBe('disconnected');
@@ -47,7 +47,7 @@ describe('HealthController', () => {
     });
 
     it('should throw when database is down', async () => {
-      prisma.$queryRawUnsafe.mockRejectedValueOnce(new Error('Connection refused'));
+      prisma.$queryRaw.mockRejectedValueOnce(new Error('Connection refused'));
       await expect(controller.ready()).rejects.toThrow('Connection refused');
     });
   });

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -5,9 +5,26 @@ import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { Public } from '../auth/decorators/public.decorator.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
-const pkg = JSON.parse(
-  readFileSync(join(__dirname, '..', '..', '..', 'package.json'), 'utf-8'),
-) as { version: string };
+function resolveVersion(): string {
+  // __dirname differs between dist (dist/src/health) and ts-jest (src/health),
+  // so probe a few candidate locations and fall back gracefully.
+  for (const rel of [
+    ['..', '..', '..'],
+    ['..', '..', '..', '..'],
+    ['..', '..'],
+  ]) {
+    try {
+      const raw = readFileSync(join(__dirname, ...rel, 'package.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as { name?: string; version?: string };
+      if (parsed.name === 'real-estate-crm' && parsed.version) return parsed.version;
+    } catch {
+      // try next candidate
+    }
+  }
+  return process.env['npm_package_version'] ?? '0.0.0';
+}
+
+const pkg = { version: resolveVersion() };
 
 interface HealthResponse {
   status: 'ok' | 'degraded';

--- a/src/uploads/uploads.service.spec.ts
+++ b/src/uploads/uploads.service.spec.ts
@@ -11,11 +11,17 @@ jest.mock('fs', () => ({
   writeFileSync: jest.fn(),
   unlinkSync: jest.fn(),
 }));
+jest.mock('fs/promises', () => ({
+  writeFile: jest.fn().mockResolvedValue(undefined),
+  unlink: jest.fn().mockResolvedValue(undefined),
+  mkdir: jest.fn().mockResolvedValue(undefined),
+}));
 
 jest.mock('sharp', () => {
   const mockSharp = jest.fn(() => ({
     resize: jest.fn().mockReturnThis(),
     toFile: jest.fn().mockResolvedValue({}),
+    toBuffer: jest.fn().mockResolvedValue(Buffer.from('img')),
   }));
   return { __esModule: true, default: mockSharp };
 });


### PR DESCRIPTION
## Summary

Follow-up #1 (batch 1) from post-autobuild stabilization. Realigns specs the autobuild left stale when it changed production code.

**Net progress: 100 → 77 failing tests; 17 → 15 failing suites.**

- `health.controller`: robust `package.json` version resolution (probe candidate paths + `npm_package_version` fallback) so ts-jest `__dirname` doesn't fail the suite — **the only production change, a genuine hardening**
- `contracts.controller`: override `IdempotencyInterceptor` (it needs Prisma DI the test module didn't provide) — fixes the whole suite
- `email.service`: add `emailPreference` prisma mock (#267 unsubscribe path)
- `uploads.service`: add `toBuffer` + `fs/promises` mocks (#215 S3 refactor)

## Scope of remainder (~77 failures, 15 suites)

Pure spec/mock realignment — **no production code changes needed**. Suites still red: clients(svc/ctrl), properties(svc/ctrl), leads(svc/ctrl), reports.service, dashboard.controller, pdf.controller, jwt.strategy, http-exception.filter, email.controller, uploads.service (the S3 refactor needs a deeper spec rework). Tracked for batch 2.

CI backend job runs tests with `|| true`, so this is a safe net-improvement; the 4 required gate checks (build/lint/typecheck, UIs, docs) are unaffected.

## Test plan
- [x] 23 more tests green, 2 suites fully fixed, zero regressions
- [x] Production code unchanged except health version hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)