### PR TITLE
fix(cd): workspace frontends + skip deploy without secrets + drop hardcoded DB passwords

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -56,6 +56,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── Preflight: is an auto-deploy target configured? ────────────────────
+  preflight:
+    name: Check deploy config
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          SSH_KEY: ${{ secrets.DEV_SERVER_SSH_KEY }}
+        run: |
+          if [ -n "$SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DEV_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+          fi
+
   # ── Build Frontend SPAs with Dev env vars ──────────────────────────────
   build-frontends:
     name: Build Dev Frontends
@@ -69,31 +87,32 @@ jobs:
           node-version: "22"
           cache: npm
 
+      # admin-ui / agent-ui are npm workspaces — install once at the root so
+      # the @crm/* shared packages link correctly.
+      - name: Install dependencies (workspaces)
+        run: npm ci
+
       - name: Build Admin UI (Dev)
-        working-directory: admin-ui
         run: |
-          npm ci
-          cat > .env.dev <<ENVEOF
+          cat > admin-ui/.env.dev <<ENVEOF
           VITE_API_URL=https://dev-api.realstate-crm.homes
           VITE_AUTHME_URL=https://dev-auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate-dev
           VITE_AUTHME_CLIENT_ID=admin-portal
           VITE_AUTHME_REDIRECT_URI=https://dev-admin.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode dev
+          npm run build --workspace admin-ui -- --mode dev
 
       - name: Build Agent UI (Dev)
-        working-directory: agent-ui
         run: |
-          npm ci
-          cat > .env.dev <<ENVEOF
+          cat > agent-ui/.env.dev <<ENVEOF
           VITE_API_URL=https://dev-api.realstate-crm.homes
           VITE_AUTHME_URL=https://dev-auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate-dev
           VITE_AUTHME_CLIENT_ID=agent-portal
           VITE_AUTHME_REDIRECT_URI=https://dev-agent.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode dev
+          npm run build --workspace agent-ui -- --mode dev
 
       - name: Upload Admin UI build
         uses: actions/upload-artifact@v4
@@ -111,7 +130,8 @@ jobs:
   migrate:
     name: Database Migration (Dev)
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -121,19 +141,15 @@ jobs:
           SSH_KEY: ${{ secrets.DEV_SERVER_SSH_KEY }}
           SSH_HOST: ${{ secrets.DEV_SERVER_HOST }}
           SSH_USER: islam
+          DEV_DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
 
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST << 'SSHEOF'
-          cd /apps/real-estate-crm
-          git fetch origin dev && git checkout dev && git pull origin dev
-          npm ci
-          export DATABASE_URL="postgresql://crm_user:real-estate-dev-password-123@localhost:5432/real_estate_crm_dev"
-          npx prisma migrate deploy
-          SSHEOF
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST \
+            "cd /apps/real-estate-crm && git fetch origin dev && git checkout dev && git pull origin dev && npm ci && DATABASE_URL='$DEV_DATABASE_URL' npx prisma migrate deploy"
 
           rm ~/.ssh/deploy_key
 
@@ -141,7 +157,8 @@ jobs:
   deploy:
     name: Deploy to Dev
     runs-on: ubuntu-latest
-    needs: [migrate, build-frontends]
+    needs: [migrate, build-frontends, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - name: Download Admin UI build

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -54,6 +54,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── Preflight: is an auto-deploy target configured? ────────────────────
+  preflight:
+    name: Check deploy config
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          SSH_KEY: ${{ secrets.PROD_SERVER_SSH_KEY }}
+        run: |
+          if [ -n "$SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::PROD_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+          fi
+
   # ── Build Frontend SPAs with Prod env vars ─────────────────────────────
   build-frontends:
     name: Build Production Frontends
@@ -67,31 +85,30 @@ jobs:
           node-version: "22"
           cache: npm
 
+      - name: Install dependencies (workspaces)
+        run: npm ci
+
       - name: Build Admin UI (Prod)
-        working-directory: admin-ui
         run: |
-          npm ci
-          cat > .env.prod <<ENVEOF
+          cat > admin-ui/.env.prod <<ENVEOF
           VITE_API_URL=https://api.realstate-crm.homes
           VITE_AUTHME_URL=https://auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate
           VITE_AUTHME_CLIENT_ID=admin-portal
           VITE_AUTHME_REDIRECT_URI=https://admin.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode prod
+          npm run build --workspace admin-ui -- --mode prod
 
       - name: Build Agent UI (Prod)
-        working-directory: agent-ui
         run: |
-          npm ci
-          cat > .env.prod <<ENVEOF
+          cat > agent-ui/.env.prod <<ENVEOF
           VITE_API_URL=https://api.realstate-crm.homes
           VITE_AUTHME_URL=https://auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate
           VITE_AUTHME_CLIENT_ID=agent-portal
           VITE_AUTHME_REDIRECT_URI=https://agent.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode prod
+          npm run build --workspace agent-ui -- --mode prod
 
       - name: Upload Admin UI build
         uses: actions/upload-artifact@v4
@@ -109,7 +126,8 @@ jobs:
   migrate:
     name: Database Migration (Production)
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -119,19 +137,15 @@ jobs:
           SSH_KEY: ${{ secrets.PROD_SERVER_SSH_KEY }}
           SSH_HOST: ${{ secrets.PROD_SERVER_HOST }}
           SSH_USER: islam
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
 
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST << 'SSHEOF'
-          cd /apps/real-estate-crm
-          git fetch origin prod && git checkout prod && git pull origin prod
-          npm ci
-          export DATABASE_URL="postgresql://crm_user:real-estate-prod-password-secure-change-me@localhost:5435/real_estate_crm_prod"
-          npx prisma migrate deploy
-          SSHEOF
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST \
+            "cd /apps/real-estate-crm && git fetch origin prod && git checkout prod && git pull origin prod && npm ci && DATABASE_URL='$PROD_DATABASE_URL' npx prisma migrate deploy"
 
           rm ~/.ssh/deploy_key
 
@@ -139,7 +153,8 @@ jobs:
   deploy:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: [build-and-push, migrate, build-frontends]
+    needs: [build-and-push, migrate, build-frontends, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - name: Download Admin UI build

--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -53,6 +53,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── Preflight: is an auto-deploy target configured? ────────────────────
+  preflight:
+    name: Check deploy config
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          SSH_KEY: ${{ secrets.QA_SERVER_SSH_KEY }}
+        run: |
+          if [ -n "$SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::QA_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+          fi
+
   # ── Build Frontend SPAs with QA env vars ───────────────────────────────
   build-frontends:
     name: Build QA Frontends
@@ -66,31 +84,30 @@ jobs:
           node-version: "22"
           cache: npm
 
+      - name: Install dependencies (workspaces)
+        run: npm ci
+
       - name: Build Admin UI (QA)
-        working-directory: admin-ui
         run: |
-          npm ci
-          cat > .env.qa <<ENVEOF
+          cat > admin-ui/.env.qa <<ENVEOF
           VITE_API_URL=https://qa-api.realstate-crm.homes
           VITE_AUTHME_URL=https://qa-auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate-qa
           VITE_AUTHME_CLIENT_ID=admin-portal
           VITE_AUTHME_REDIRECT_URI=https://qa-admin.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode qa
+          npm run build --workspace admin-ui -- --mode qa
 
       - name: Build Agent UI (QA)
-        working-directory: agent-ui
         run: |
-          npm ci
-          cat > .env.qa <<ENVEOF
+          cat > agent-ui/.env.qa <<ENVEOF
           VITE_API_URL=https://qa-api.realstate-crm.homes
           VITE_AUTHME_URL=https://qa-auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate-qa
           VITE_AUTHME_CLIENT_ID=agent-portal
           VITE_AUTHME_REDIRECT_URI=https://qa-agent.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode qa
+          npm run build --workspace agent-ui -- --mode qa
 
       - name: Upload Admin UI build
         uses: actions/upload-artifact@v4
@@ -108,7 +125,8 @@ jobs:
   migrate:
     name: Database Migration (QA)
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -118,19 +136,15 @@ jobs:
           SSH_KEY: ${{ secrets.QA_SERVER_SSH_KEY }}
           SSH_HOST: ${{ secrets.QA_SERVER_HOST }}
           SSH_USER: islam
+          QA_DATABASE_URL: ${{ secrets.QA_DATABASE_URL }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
 
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST << 'SSHEOF'
-          cd /apps/real-estate-crm
-          git fetch origin qa && git checkout qa && git pull origin qa
-          npm ci
-          export DATABASE_URL="postgresql://crm_user:real-estate-qa-password-123@localhost:5433/real_estate_crm_qa"
-          npx prisma migrate deploy
-          SSHEOF
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST \
+            "cd /apps/real-estate-crm && git fetch origin qa && git checkout qa && git pull origin qa && npm ci && DATABASE_URL='$QA_DATABASE_URL' npx prisma migrate deploy"
 
           rm ~/.ssh/deploy_key
 
@@ -138,7 +152,8 @@ jobs:
   deploy:
     name: Deploy to QA
     runs-on: ubuntu-latest
-    needs: [build-and-push, migrate, build-frontends]
+    needs: [build-and-push, migrate, build-frontends, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - name: Download Admin UI build

--- a/.github/workflows/cd-uat.yml
+++ b/.github/workflows/cd-uat.yml
@@ -53,6 +53,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── Preflight: is an auto-deploy target configured? ────────────────────
+  preflight:
+    name: Check deploy config
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          SSH_KEY: ${{ secrets.UAT_SERVER_SSH_KEY }}
+        run: |
+          if [ -n "$SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::UAT_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+          fi
+
   # ── Build Frontend SPAs with UAT env vars ──────────────────────────────
   build-frontends:
     name: Build UAT Frontends
@@ -66,31 +84,30 @@ jobs:
           node-version: "22"
           cache: npm
 
+      - name: Install dependencies (workspaces)
+        run: npm ci
+
       - name: Build Admin UI (UAT)
-        working-directory: admin-ui
         run: |
-          npm ci
-          cat > .env.uat <<ENVEOF
+          cat > admin-ui/.env.uat <<ENVEOF
           VITE_API_URL=https://uat-api.realstate-crm.homes
           VITE_AUTHME_URL=https://uat-auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate-uat
           VITE_AUTHME_CLIENT_ID=admin-portal
           VITE_AUTHME_REDIRECT_URI=https://uat-admin.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode uat
+          npm run build --workspace admin-ui -- --mode uat
 
       - name: Build Agent UI (UAT)
-        working-directory: agent-ui
         run: |
-          npm ci
-          cat > .env.uat <<ENVEOF
+          cat > agent-ui/.env.uat <<ENVEOF
           VITE_API_URL=https://uat-api.realstate-crm.homes
           VITE_AUTHME_URL=https://uat-auth.realstate-crm.homes
           VITE_AUTHME_REALM=real-estate-uat
           VITE_AUTHME_CLIENT_ID=agent-portal
           VITE_AUTHME_REDIRECT_URI=https://uat-agent.realstate-crm.homes/callback
           ENVEOF
-          npm run build -- --mode uat
+          npm run build --workspace agent-ui -- --mode uat
 
       - name: Upload Admin UI build
         uses: actions/upload-artifact@v4
@@ -108,7 +125,8 @@ jobs:
   migrate:
     name: Database Migration (UAT)
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -118,19 +136,15 @@ jobs:
           SSH_KEY: ${{ secrets.UAT_SERVER_SSH_KEY }}
           SSH_HOST: ${{ secrets.UAT_SERVER_HOST }}
           SSH_USER: islam
+          UAT_DATABASE_URL: ${{ secrets.UAT_DATABASE_URL }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
 
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST << 'SSHEOF'
-          cd /apps/real-estate-crm
-          git fetch origin uat && git checkout uat && git pull origin uat
-          npm ci
-          export DATABASE_URL="postgresql://crm_user:real-estate-uat-password-123@localhost:5434/real_estate_crm_uat"
-          npx prisma migrate deploy
-          SSHEOF
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $SSH_USER@$SSH_HOST \
+            "cd /apps/real-estate-crm && git fetch origin uat && git checkout uat && git pull origin uat && npm ci && DATABASE_URL='$UAT_DATABASE_URL' npx prisma migrate deploy"
 
           rm ~/.ssh/deploy_key
 
@@ -138,7 +152,8 @@ jobs:
   deploy:
     name: Deploy to UAT
     runs-on: ubuntu-latest
-    needs: [build-and-push, migrate, build-frontends]
+    needs: [build-and-push, migrate, build-frontends, preflight]
+    if: needs.preflight.outputs.deploy_enabled == 'true'
 
     steps:
       - name: Download Admin UI build


### PR DESCRIPTION
## Summary

The **CD → Dev** pipeline failed on every push to `dev` (the screenshot). This is the auto-deploy pipeline (separate from the CI gate, which is green). Two root causes — fixed across all 4 SSH-deploy CD workflows (dev/qa/uat/prod):

### 1. `build-frontends` workspace bug
`cd admin-ui && npm ci` broke when admin-ui/agent-ui became npm workspaces (no own lockfile → `@crm/*` 404). Now: root `npm ci` + `npm run build --workspace`.

### 2. No deploy target → jobs hard-failed
`migrate`/`deploy` SSH into a server that was never provisioned (no `*_SERVER_SSH_KEY` secret). Added a `preflight` job; migrate/deploy now `if: needs.preflight.outputs.deploy_enabled == 'true'` → **skip cleanly** (workflow green) until a target + secrets exist. `build-and-push` + `build-frontends` still run.

### 3. 🔒 Removed 4 committed DB passwords
`real-estate-{dev,qa,uat}-password-123` and `real-estate-prod-password-secure-change-me` were hardcoded in the migrate jobs. `DATABASE_URL` now comes from per-env secrets (`{DEV,QA,UAT,PROD}_DATABASE_URL`).

`cd.yml` (triggers on non-existent `main`, no secrets) left as-is.

## Verified
- ✅ `npm run build --workspace admin-ui -- --mode dev` works
- ✅ all 8 workflow YAMLs valid
- ✅ no hardcoded DB creds remain in any cd-*.yml

## Result
After merge, CD → Dev will be **green**: build the image + frontends, skip deploy (no server). Re-enabling deploy later = just add the `*_SERVER_SSH_KEY` / `*_DATABASE_URL` secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)