### PR TITLE
fix(cd): gate auto-deploy on opt-in repo variable (not secret presence)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -64,14 +64,15 @@ jobs:
       deploy_enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - id: check
-        env:
-          SSH_KEY: ${{ secrets.DEV_SERVER_SSH_KEY }}
         run: |
-          if [ -n "$SSH_KEY" ]; then
+          # Auto-deploy is opt-in. It stays OFF until the repo variable
+          # DEV_DEPLOY_ENABLED is set to 'true' (Settings → Variables).
+          # (Secrets exist but point at a server that isn't running.)
+          if [ "${{ vars.DEV_DEPLOY_ENABLED }}" = "true" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DEV_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+            echo "::notice::Auto-deploy disabled — set repo variable DEV_DEPLOY_ENABLED=true to enable. Build & push still runs."
           fi
 
   # ── Build Frontend SPAs with Dev env vars ──────────────────────────────

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -62,14 +62,14 @@ jobs:
       deploy_enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - id: check
-        env:
-          SSH_KEY: ${{ secrets.PROD_SERVER_SSH_KEY }}
         run: |
-          if [ -n "$SSH_KEY" ]; then
+          # Auto-deploy is opt-in. Stays OFF until repo variable
+          # PROD_DEPLOY_ENABLED is set to 'true' (Settings → Variables).
+          if [ "${{ vars.PROD_DEPLOY_ENABLED }}" = "true" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::PROD_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+            echo "::notice::Auto-deploy disabled — set repo variable PROD_DEPLOY_ENABLED=true to enable. Build & push still runs."
           fi
 
   # ── Build Frontend SPAs with Prod env vars ─────────────────────────────

--- a/.github/workflows/cd-qa.yml
+++ b/.github/workflows/cd-qa.yml
@@ -61,14 +61,14 @@ jobs:
       deploy_enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - id: check
-        env:
-          SSH_KEY: ${{ secrets.QA_SERVER_SSH_KEY }}
         run: |
-          if [ -n "$SSH_KEY" ]; then
+          # Auto-deploy is opt-in. Stays OFF until repo variable
+          # QA_DEPLOY_ENABLED is set to 'true' (Settings → Variables).
+          if [ "${{ vars.QA_DEPLOY_ENABLED }}" = "true" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::QA_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+            echo "::notice::Auto-deploy disabled — set repo variable QA_DEPLOY_ENABLED=true to enable. Build & push still runs."
           fi
 
   # ── Build Frontend SPAs with QA env vars ───────────────────────────────

--- a/.github/workflows/cd-uat.yml
+++ b/.github/workflows/cd-uat.yml
@@ -61,14 +61,14 @@ jobs:
       deploy_enabled: ${{ steps.check.outputs.enabled }}
     steps:
       - id: check
-        env:
-          SSH_KEY: ${{ secrets.UAT_SERVER_SSH_KEY }}
         run: |
-          if [ -n "$SSH_KEY" ]; then
+          # Auto-deploy is opt-in. Stays OFF until repo variable
+          # UAT_DEPLOY_ENABLED is set to 'true' (Settings → Variables).
+          if [ "${{ vars.UAT_DEPLOY_ENABLED }}" = "true" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::UAT_SERVER_SSH_KEY not configured — skipping migrate/deploy. Build & push still runs."
+            echo "::notice::Auto-deploy disabled — set repo variable UAT_DEPLOY_ENABLED=true to enable. Build & push still runs."
           fi
 
   # ── Build Frontend SPAs with UAT env vars ──────────────────────────────


### PR DESCRIPTION
## Why the previous fix wasn't enough

PR #339 gated deploy on *secret presence*. But `gh secret list` shows `DEV_SERVER_SSH_KEY` / `*_SERVER_HOST` / `*_DATABASE_URL` **are configured** (since 2026-03) — they just point at servers that aren't running. So preflight said `enabled=true`, `migrate` ran and failed (9s, SSH).

## Fix

Per "no dev server — disable auto-deploy", gate on an **explicit opt-in repo variable**:

```
migrate/deploy run only if  vars.<ENV>_DEPLOY_ENABLED == 'true'
```

No such variable exists → `migrate`/`deploy` **skip** → CD → {Dev,QA,UAT,Prod} go **fully green** (image + frontends build; deploy skipped).

**Re-enabling later** = Settings → Secrets and variables → Variables → add `DEV_DEPLOY_ENABLED=true` (secrets are already in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)